### PR TITLE
Moves you from the AWT.Color in the Layer Geos to Geckolibs Core Color

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     includedDependencies 'meldexun:ASMUtil:1.0.0@jar'
     includedDependencies 'meldexun:ReflectionUtil:1.0.0@jar'
 
-    implementation fg.deobf('software.bernie.geckolib:forge-1.12.2-geckolib:3.0.13')
+    implementation fg.deobf('software.bernie.geckolib:forge-1.12.2-geckolib:3.0.19')
 
     atDependencies 'curse.maven:ReachFix-556777:3584670'
     atDependencies fg.deobf('mezz.jei:jei_1.12.2:4.16.1.302')

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerBossDeathGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerBossDeathGeo.java
@@ -1,10 +1,10 @@
 package team.cqr.cqrepoured.client.render.entity.layer.geo;
 
-import java.awt.Color;
 import java.util.function.Function;
 
 import net.minecraft.util.ResourceLocation;
 import software.bernie.geckolib3.core.IAnimatable;
+import software.bernie.geckolib3.core.util.Color;
 import software.bernie.geckolib3.renderers.geo.GeoEntityRenderer;
 import team.cqr.cqrepoured.client.util.BossDeathRayHelper;
 import team.cqr.cqrepoured.entity.bases.AbstractEntityCQRBoss;

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerElectrocuteGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerElectrocuteGeo.java
@@ -1,11 +1,11 @@
 package team.cqr.cqrepoured.client.render.entity.layer.geo;
 
-import java.awt.Color;
 import java.util.function.Function;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.ResourceLocation;
 import software.bernie.geckolib3.core.IAnimatable;
+import software.bernie.geckolib3.core.util.Color;
 import software.bernie.geckolib3.renderers.geo.GeoEntityRenderer;
 import team.cqr.cqrepoured.client.render.entity.layer.IElectrocuteLayerRenderLogic;
 

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerGlowingAreasGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerGlowingAreasGeo.java
@@ -1,11 +1,11 @@
 package team.cqr.cqrepoured.client.render.entity.layer.geo;
 
-import java.awt.Color;
 import java.util.function.Function;
 
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.ResourceLocation;
 import software.bernie.geckolib3.core.IAnimatable;
+import software.bernie.geckolib3.core.util.Color;
 import software.bernie.geckolib3.renderers.geo.GeoEntityRenderer;
 import team.cqr.cqrepoured.client.render.texture.AutoGlowingTexture;
 import team.cqr.cqrepoured.client.util.EmissiveUtil;

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerMagicArmorGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerMagicArmorGeo.java
@@ -1,6 +1,5 @@
 package team.cqr.cqrepoured.client.render.entity.layer.geo;
 
-import java.awt.Color;
 import java.util.function.Function;
 
 import net.minecraft.client.Minecraft;
@@ -8,6 +7,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import software.bernie.geckolib3.core.IAnimatable;
+import software.bernie.geckolib3.core.util.Color;
 import software.bernie.geckolib3.renderers.geo.GeoEntityRenderer;
 import team.cqr.cqrepoured.client.render.entity.RenderCQREntityGeo;
 import team.cqr.cqrepoured.entity.bases.AbstractEntityCQR;

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -12,7 +12,7 @@
   "logoFile": "assets/cqrepoured/logo.png",
   "screenshots": [],
   "dependencies": ["phosphor-lighting", "jei", "entity_culling"],
-  "requiredMods": ["forge@[14.23.5.2817,)", "geckolib3@[3.0.13,)", "reachfix@[1.0.1,)"],
+  "requiredMods": ["forge@[14.23.5.2817,)", "geckolib3@[3.0.19,)", "reachfix@[1.0.1,)"],
   "useDependencyInformation": true
 }
 ]


### PR DESCRIPTION
Moving Geckolib from AWT Color to the core class we have. This PR fixes your 4 layer Geos (it's all that broke, pulled source in IDE and tested before making this PR). Also bumps the required version to the version that has the new Core Color calls. It's currently archived on CurseForge until you can merge and hopefully release this soon. 