### PR TITLE
Fix ConcurrentModificationExceptions in DungeonGenerationHelper

### DIFF
--- a/src/main/java/team/cqr/cqrepoured/event/world/structure/generation/DungeonGenerationHelper.java
+++ b/src/main/java/team/cqr/cqrepoured/event/world/structure/generation/DungeonGenerationHelper.java
@@ -1,6 +1,6 @@
 package team.cqr.cqrepoured.event.world.structure.generation;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -26,8 +26,8 @@ import team.cqr.cqrepoured.CQRMain;
 @EventBusSubscriber(modid = CQRMain.MODID)
 public class DungeonGenerationHelper {
 
-	private static final Map<Integer, Set<EntityPlayer>> TRAVELING_PLAYERS = new HashMap<>();
-	private static final Map<World, Set<ChunkPos>> DELAYED_CHUNKS = new HashMap<>();
+	private static final Map<Integer, Set<EntityPlayer>> TRAVELING_PLAYERS = new ConcurrentHashMap<>();
+	private static final Map<World, Set<ChunkPos>> DELAYED_CHUNKS = new ConcurrentHashMap<>();
 	private static boolean isGeneratingDelayedChunks = false;
 
 	public static void onWorldUnloadEvent(World world) {


### PR DESCRIPTION
In large modpacks, updating the hash maps from DungeonGenerationHelper seems to cause CMEs when switching dimensions, using a modified version of the Hexxit II modpack as an example: https://mclo.gs/cq7vTCi

Implementing concurrent hash maps for this purpose solved this issue and was tested over several hours of gameplay.