### PR TITLE
Decrease memory consumption of cached CQStructure

### DIFF
--- a/src/main/java/team/cqr/cqrepoured/util/BlockStateGenArray.java
+++ b/src/main/java/team/cqr/cqrepoured/util/BlockStateGenArray.java
@@ -113,15 +113,15 @@ public class BlockStateGenArray {
 	}
 
 	public boolean addBlockState(BlockPos pos, IBlockState blockState, GenerationPhase phase, EnumPriority priority) {
-		return this.addInternal(phase, pos, new PreparableBlockInfo(blockState, null), priority);
+		return this.addInternal(phase, pos, PreparableBlockInfo.of(blockState, null), priority);
 	}
 
 	public boolean addBlockState(BlockPos pos, IBlockState blockState, NBTTagCompound nbt, GenerationPhase phase, EnumPriority priority) {
-		return this.addInternal(phase, pos, new PreparableBlockInfo(blockState, nbt), priority);
+		return this.addInternal(phase, pos, PreparableBlockInfo.of(blockState, nbt), priority);
 	}
 
 	public boolean addSpawner(BlockPos pos, IBlockState blockState, NBTTagCompound nbt, GenerationPhase phase, EnumPriority priority) {
-		return this.addInternal(phase, pos, new PreparableBlockInfo(blockState, nbt), priority);
+		return this.addInternal(phase, pos, PreparableBlockInfo.of(blockState, nbt), priority);
 	}
 
 	public boolean addEntity(BlockPos structurePos, Entity entity) {

--- a/src/main/java/team/cqr/cqrepoured/util/BlockStateGenArray.java
+++ b/src/main/java/team/cqr/cqrepoured/util/BlockStateGenArray.java
@@ -131,7 +131,7 @@ public class BlockStateGenArray {
 	public boolean addInternal(GenerationPhase phase, BlockPos pos, PreparablePosInfo blockInfo, EnumPriority priority) {
 		boolean added = false;
 		Map<BlockPos, PriorityBlockInfo> mapToAdd = this.getMapFromPhase(phase);
-		BlockPos p = new BlockPos(pos);
+		BlockPos p = pos.toImmutable();
 		PriorityBlockInfo old = mapToAdd.get(p);
 
 		if (old == null || (priority.getValue() > old.getPriority().getValue())) {

--- a/src/main/java/team/cqr/cqrepoured/util/BlockStateGenArray.java
+++ b/src/main/java/team/cqr/cqrepoured/util/BlockStateGenArray.java
@@ -113,25 +113,25 @@ public class BlockStateGenArray {
 	}
 
 	public boolean addBlockState(BlockPos pos, IBlockState blockState, GenerationPhase phase, EnumPriority priority) {
-		return this.addInternal(phase, new PreparableBlockInfo(pos, blockState, null), priority);
+		return this.addInternal(phase, pos, new PreparableBlockInfo(blockState, null), priority);
 	}
 
 	public boolean addBlockState(BlockPos pos, IBlockState blockState, NBTTagCompound nbt, GenerationPhase phase, EnumPriority priority) {
-		return this.addInternal(phase, new PreparableBlockInfo(pos, blockState, nbt), priority);
+		return this.addInternal(phase, pos, new PreparableBlockInfo(blockState, nbt), priority);
 	}
 
 	public boolean addSpawner(BlockPos pos, IBlockState blockState, NBTTagCompound nbt, GenerationPhase phase, EnumPriority priority) {
-		return this.addInternal(phase, new PreparableBlockInfo(pos, blockState, nbt), priority);
+		return this.addInternal(phase, pos, new PreparableBlockInfo(blockState, nbt), priority);
 	}
 
 	public boolean addEntity(BlockPos structurePos, Entity entity) {
 		return this.addInternal(new PreparableEntityInfo(structurePos, entity));
 	}
 
-	public boolean addInternal(GenerationPhase phase, PreparablePosInfo blockInfo, EnumPriority priority) {
+	public boolean addInternal(GenerationPhase phase, BlockPos pos, PreparablePosInfo blockInfo, EnumPriority priority) {
 		boolean added = false;
 		Map<BlockPos, PriorityBlockInfo> mapToAdd = this.getMapFromPhase(phase);
-		BlockPos p = new BlockPos(blockInfo.getX(), blockInfo.getY(), blockInfo.getZ());
+		BlockPos p = new BlockPos(pos);
 		PriorityBlockInfo old = mapToAdd.get(p);
 
 		if (old == null || (priority.getValue() > old.getPriority().getValue())) {

--- a/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
+++ b/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
@@ -67,14 +67,13 @@ public class StructureUpper {
 		BlockPos size = structure.getSize();
 		PreparablePosInfo[][][] blocks = structure.getBlocks();
 		MutableBlockPos pos = new MutableBlockPos();
-		PreparablePosInfo emptyInfo = PreparableEmptyInfo.INSTANCE;
-		for (int x = 0; x < size.getX(); x++) {
+        for (int x = 0; x < size.getX(); x++) {
 			for (int y = 0; y < size.getY(); y++) {
 				for (int z = 0; z < size.getZ(); z++) {
 					pos.setPos(x, y, z);
 					PreparablePosInfo block = blocks != null ? blocks[x][y][z] : null;
 					if (block == null) {
-						block = emptyInfo;
+						block = PreparableEmptyInfo.INSTANCE;
 					}
 					Class<? extends PreparablePosInfo> blockClass = block.getClass();
 					if (blockClass == PreparableEmptyInfo.class) {

--- a/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
+++ b/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
@@ -2,6 +2,7 @@ package team.cqr.cqrepoured.util.datafixer;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
@@ -65,16 +66,13 @@ public class StructureUpper {
 		structure.getEntityInfoList().forEach(entity -> entityBuf.writeInt(addEntity(entityChunk, entity.getEntityData())));
 
 		BlockPos size = structure.getSize();
-		PreparablePosInfo[][][] blocks = structure.getBlocks();
+		List<PreparablePosInfo> blocks = structure.getBlockInfoList();
 		MutableBlockPos pos = new MutableBlockPos();
-        for (int x = 0; x < size.getX(); x++) {
+		for (int x = 0; x < size.getX(); x++) {
 			for (int y = 0; y < size.getY(); y++) {
 				for (int z = 0; z < size.getZ(); z++) {
 					pos.setPos(x, y, z);
-					PreparablePosInfo block = blocks != null ? blocks[x][y][z] : null;
-					if (block == null) {
-						block = PreparableEmptyInfo.INSTANCE;
-					}
+					PreparablePosInfo block = blocks.get((x * size.getY() + y) * size.getZ() + z);
 					Class<? extends PreparablePosInfo> blockClass = block.getClass();
 					if (blockClass == PreparableEmptyInfo.class) {
 						PreparablePosInfo.Registry.write(block, blockBuf, palette, compoundList);

--- a/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
+++ b/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
@@ -2,7 +2,6 @@ package team.cqr.cqrepoured.util.datafixer;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
@@ -66,13 +65,17 @@ public class StructureUpper {
 		structure.getEntityInfoList().forEach(entity -> entityBuf.writeInt(addEntity(entityChunk, entity.getEntityData())));
 
 		BlockPos size = structure.getSize();
-		List<PreparablePosInfo> blocks = structure.getBlockInfoList();
+		PreparablePosInfo[][][] blocks = structure.getBlocks();
 		MutableBlockPos pos = new MutableBlockPos();
+		PreparablePosInfo emptyInfo = PreparableEmptyInfo.INSTANCE;
 		for (int x = 0; x < size.getX(); x++) {
 			for (int y = 0; y < size.getY(); y++) {
 				for (int z = 0; z < size.getZ(); z++) {
 					pos.setPos(x, y, z);
-					PreparablePosInfo block = blocks.get((x * size.getY() + y) * size.getZ() + z);
+					PreparablePosInfo block = blocks != null ? blocks[x][y][z] : null;
+					if (block == null) {
+						block = emptyInfo;
+					}
 					Class<? extends PreparablePosInfo> blockClass = block.getClass();
 					if (blockClass == PreparableEmptyInfo.class) {
 						PreparablePosInfo.Registry.write(block, blockBuf, palette, compoundList);

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/PlateauBuilder.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/PlateauBuilder.java
@@ -44,7 +44,7 @@ public class PlateauBuilder {
 						}
 					}
 
-					partBuilder.add(iX, iY, iZ, new PreparableBlockInfo(fillBlock.getDefaultState(), null));
+					partBuilder.add(iX, iY, iZ, PreparableBlockInfo.of(fillBlock.getDefaultState(), null));
 				}
 			}
 		}
@@ -84,7 +84,7 @@ public class PlateauBuilder {
 						}
 					}
 
-					partBuilder.add(iX, iY, iZ, new PreparableBlockInfo(fillBlock.getDefaultState(), null));
+					partBuilder.add(iX, iY, iZ, PreparableBlockInfo.of(fillBlock.getDefaultState(), null));
 				}
 			}
 		}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/PlateauBuilder.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/PlateauBuilder.java
@@ -44,7 +44,7 @@ public class PlateauBuilder {
 						}
 					}
 
-					partBuilder.add(new PreparableBlockInfo(iX, iY, iZ, fillBlock.getDefaultState(), null));
+					partBuilder.add(iX, iY, iZ, new PreparableBlockInfo(fillBlock.getDefaultState(), null));
 				}
 			}
 		}
@@ -84,7 +84,7 @@ public class PlateauBuilder {
 						}
 					}
 
-					partBuilder.add(new PreparableBlockInfo(iX, iY, iZ, fillBlock.getDefaultState(), null));
+					partBuilder.add(iX, iY, iZ, new PreparableBlockInfo(fillBlock.getDefaultState(), null));
 				}
 			}
 		}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
@@ -101,13 +101,13 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 			private final int x, y, z;
 			private final PreparablePosInfo info;
 
-            private InfoPosEntry(int x, int y, int z, PreparablePosInfo info) {
-                this.x = x;
-                this.y = y;
-                this.z = z;
-                this.info = info;
-            }
-        }
+			private InfoPosEntry(int x, int y, int z, PreparablePosInfo info) {
+				this.x = x;
+				this.y = y;
+				this.z = z;
+				this.info = info;
+			}
+		}
 
 		private static final Comparator<GeneratablePosInfo> CQR_COMPARATOR = (g1, g2) -> {
 			if (g1.getChunkY() < g2.getChunkY()) {
@@ -157,7 +157,7 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 		}
 
 		public Builder add(int x, int y, int z, PreparablePosInfo block) {
-			this.blocks.add(new InfoPosEntry(x, y ,z, block));
+			this.blocks.add(new InfoPosEntry(x, y, z, block));
 			return this;
 		}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -151,10 +152,6 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 
 		private final List<InfoPosEntry> blocks = new ArrayList<>();
 
-		public Builder add(PreparablePosInfo block) {
-			throw new UnsupportedOperationException("Use add(int,int,int,PreparablePosInfo) instead");
-		}
-
 		public Builder add(BlockPos pos, PreparablePosInfo block) {
 			return add(pos.getX(), pos.getY(), pos.getZ(), block);
 		}
@@ -164,8 +161,9 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 			return this;
 		}
 
-		public Builder addAll(Collection<? extends PreparablePosInfo> blocks) {
-			throw new UnsupportedOperationException("Use add(int,int,int,PreparablePosInfo) for each block instead");
+		public Builder addAll(Map<? extends BlockPos, ? extends PreparablePosInfo> blocks) {
+			blocks.forEach(this::add);
+			return this;
 		}
 
 		public Builder addAll(PreparablePosInfo[][][] blocks, BlockPos size) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
@@ -97,6 +97,7 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 	}
 
 	public static class Builder implements IDungeonPartBuilder {
+
 		private static final class InfoPosEntry {
 			private final int x, y, z;
 			private final PreparablePosInfo info;
@@ -153,7 +154,7 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 		private final List<InfoPosEntry> blocks = new ArrayList<>();
 
 		public Builder add(BlockPos pos, PreparablePosInfo block) {
-			return add(pos.getX(), pos.getY(), pos.getZ(), block);
+			return this.add(pos.getX(), pos.getY(), pos.getZ(), block);
 		}
 
 		public Builder add(int x, int y, int z, PreparablePosInfo block) {
@@ -170,7 +171,7 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 			for (int x = 0; x < size.getX(); x++) {
 				for (int y = 0; y < size.getY(); y++) {
 					for (int z = 0; z < size.getZ(); z++) {
-                        this.blocks.add(new InfoPosEntry(x, y, z, blocks.get((x * size.getY() + y) * size.getZ() + z)));
+						this.blocks.add(new InfoPosEntry(x, y, z, blocks.get((x * size.getY() + y) * size.getZ() + z)));
 					}
 				}
 			}
@@ -180,10 +181,10 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 		@Override
 		public BlockDungeonPart build(World world, DungeonPlacement placement) {
 			List<GeneratablePosInfo> list = this.blocks.stream()
-				.map(entry -> entry.info.prepare(world, placement, entry.x, entry.y, entry.z))
-				.filter(Objects::nonNull)
-				.sorted(CQR_COMPARATOR)
-				.collect(Collectors.toList());
+					.map(entry -> entry.info.prepare(world, placement, entry.x, entry.y, entry.z))
+					.filter(Objects::nonNull)
+					.sorted(CQR_COMPARATOR)
+					.collect(Collectors.toList());
 			List<GeneratableChunkInfo> list1 = new ArrayList<>();
 
 			for (int i = 0; i < list.size(); i++) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
@@ -96,6 +96,17 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 	}
 
 	public static class Builder implements IDungeonPartBuilder {
+		private static final class InfoPosEntry {
+			private final int x, y, z;
+			private final PreparablePosInfo info;
+
+            private InfoPosEntry(int x, int y, int z, PreparablePosInfo info) {
+                this.x = x;
+                this.y = y;
+                this.z = z;
+                this.info = info;
+            }
+        }
 
 		private static final Comparator<GeneratablePosInfo> CQR_COMPARATOR = (g1, g2) -> {
 			if (g1.getChunkY() < g2.getChunkY()) {
@@ -138,22 +149,46 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 			return 0;
 		};
 
-		private final List<PreparablePosInfo> blocks = new ArrayList<>();
+		private final List<InfoPosEntry> blocks = new ArrayList<>();
 
 		public Builder add(PreparablePosInfo block) {
-			this.blocks.add(block);
+			throw new UnsupportedOperationException("Use add(int,int,int,PreparablePosInfo) instead");
+		}
+
+		public Builder add(BlockPos pos, PreparablePosInfo block) {
+			return add(pos.getX(), pos.getY(), pos.getZ(), block);
+		}
+
+		public Builder add(int x, int y, int z, PreparablePosInfo block) {
+			this.blocks.add(new InfoPosEntry(x, y ,z, block));
 			return this;
 		}
 
 		public Builder addAll(Collection<? extends PreparablePosInfo> blocks) {
-			this.blocks.addAll(blocks);
+			throw new UnsupportedOperationException("Use add(int,int,int,PreparablePosInfo) for each block instead");
+		}
+
+		public Builder addAll(PreparablePosInfo[][][] blocks, BlockPos size) {
+			for (int x = 0; x < size.getX(); x++) {
+				for (int y = 0; y < size.getY(); y++) {
+					for (int z = 0; z < size.getZ(); z++) {
+						PreparablePosInfo info = blocks[x][y][z];
+						if (info != null) {
+							this.blocks.add(new InfoPosEntry(x, y, z, info));
+						}
+					}
+				}
+			}
 			return this;
 		}
 
 		@Override
 		public BlockDungeonPart build(World world, DungeonPlacement placement) {
-			List<GeneratablePosInfo> list = this.blocks.stream().map(preparable -> preparable.prepare(world, placement)).filter(Objects::nonNull).collect(Collectors.toList());
-			list.sort(CQR_COMPARATOR);
+			List<GeneratablePosInfo> list = this.blocks.stream()
+				.map(entry -> entry.info.prepare(world, placement, entry.x, entry.y, entry.z))
+				.filter(Objects::nonNull)
+				.sorted(CQR_COMPARATOR)
+				.collect(Collectors.toList());
 			List<GeneratableChunkInfo> list1 = new ArrayList<>();
 
 			for (int i = 0; i < list.size(); i++) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/BlockDungeonPart.java
@@ -166,14 +166,11 @@ public class BlockDungeonPart implements IDungeonPart, IProtectable {
 			return this;
 		}
 
-		public Builder addAll(PreparablePosInfo[][][] blocks, BlockPos size) {
+		public Builder addAll(List<PreparablePosInfo> blocks, BlockPos size) {
 			for (int x = 0; x < size.getX(); x++) {
 				for (int y = 0; y < size.getY(); y++) {
 					for (int z = 0; z < size.getZ(); z++) {
-						PreparablePosInfo info = blocks[x][y][z];
-						if (info != null) {
-							this.blocks.add(new InfoPosEntry(x, y, z, info));
-						}
+                        this.blocks.add(new InfoPosEntry(x, y, z, blocks.get((x * size.getY() + y) * size.getZ() + z)));
 					}
 				}
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
@@ -197,7 +197,7 @@ public class PlateauDungeonPart implements IDungeonPart {
 		}
 
 		public void markGround(CQStructure structure, BlockPos pos, Mirror mirror, Rotation rotation) {
-			List<PreparablePosInfo> blocks = structure.getBlockInfoList();
+			PreparablePosInfo[][][] blocks = structure.getBlocks();
 			BlockPos size = structure.getSize();
 			BlockPos offset = Offset.NORTH_EAST.apply(BlockPos.ORIGIN, structure, mirror, rotation);
 			int offsetX = offset.getX() == 0 ? 0 : offset.getX() - 1;
@@ -214,7 +214,7 @@ public class PlateauDungeonPart implements IDungeonPart {
 						continue;
 					}
 					int y = Math.min(this.endY + 1 - pos.getY(), size.getY() - 1);
-					while (y >= 0 && blocks.get((x * size.getY() + y) * size.getZ() + z) instanceof PreparableEmptyInfo) {
+					while (y >= 0 && blocks != null && blocks[x][y][z] == null) {
 						y--;
 					}
 					if (y < 0) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
@@ -197,13 +197,13 @@ public class PlateauDungeonPart implements IDungeonPart {
 		}
 
 		public void markGround(CQStructure structure, BlockPos pos, Mirror mirror, Rotation rotation) {
-			PreparablePosInfo[][][] blocks = structure.getBlocks();
+			List<PreparablePosInfo> blocks = structure.getBlockInfoList();
 			BlockPos size = structure.getSize();
 			BlockPos offset = Offset.NORTH_EAST.apply(BlockPos.ORIGIN, structure, mirror, rotation);
 			int offsetX = offset.getX() == 0 ? 0 : offset.getX() - 1;
 			int offsetZ = offset.getZ() == 0 ? 0 : offset.getZ() - 1;
-			for (int x = 0; x < size.getX(); x++) {
-				for (int z = 0; z < size.getZ(); z++) {
+			for (int x = 0; x < structure.getSize().getX(); x++) {
+				for (int z = 0; z < structure.getSize().getZ(); z++) {
 					MutableBlockPos transformed = DungeonPlacement.transform(x, 0, z, mirror, rotation);
 					int x1 = transformed.getX();
 					int z1 = transformed.getZ();
@@ -214,7 +214,7 @@ public class PlateauDungeonPart implements IDungeonPart {
 						continue;
 					}
 					int y = Math.min(this.endY + 1 - pos.getY(), size.getY() - 1);
-					while (y >= 0 && blocks[x][y][z] == null) {
+					while (y >= 0 && blocks.get((x * size.getY() + y) * size.getZ() + z) instanceof PreparableEmptyInfo) {
 						y--;
 					}
 					if (y < 0) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
@@ -202,8 +202,8 @@ public class PlateauDungeonPart implements IDungeonPart {
 			BlockPos offset = Offset.NORTH_EAST.apply(BlockPos.ORIGIN, structure, mirror, rotation);
 			int offsetX = offset.getX() == 0 ? 0 : offset.getX() - 1;
 			int offsetZ = offset.getZ() == 0 ? 0 : offset.getZ() - 1;
-			for (int x = 0; x < structure.getSize().getX(); x++) {
-				for (int z = 0; z < structure.getSize().getZ(); z++) {
+			for (int x = 0; x < size.getX(); x++) {
+				for (int z = 0; z < size.getZ(); z++) {
 					MutableBlockPos transformed = DungeonPlacement.transform(x, 0, z, mirror, rotation);
 					int x1 = transformed.getX();
 					int z1 = transformed.getZ();
@@ -214,7 +214,7 @@ public class PlateauDungeonPart implements IDungeonPart {
 						continue;
 					}
 					int y = Math.min(this.endY + 1 - pos.getY(), size.getY() - 1);
-					while (y >= 0 && blocks != null && blocks[x][y][z] == null) {
+					while (y >= 0 && blocks[x][y][z] == null) {
 						y--;
 					}
 					if (y < 0) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBannerInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBannerInfo.java
@@ -45,7 +45,7 @@ public class PreparableBannerInfo extends PreparableBlockInfo {
 			if (BannerHelper.isCQBanner(tileEntity)) {
 				return new PreparableBannerInfo(state, IFactory.writeTileEntityToNBT(tileEntity));
 			}
-			return new PreparableBlockInfo(state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
+			return PreparableBlockInfo.of(state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBannerInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBannerInfo.java
@@ -24,12 +24,8 @@ import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePa
 
 public class PreparableBannerInfo extends PreparableBlockInfo {
 
-	public PreparableBannerInfo(BlockPos pos, IBlockState state, @Nullable NBTTagCompound tileEntityData) {
-		this(pos.getX(), pos.getY(), pos.getZ(), state, tileEntityData);
-	}
-
-	public PreparableBannerInfo(int x, int y, int z, IBlockState state, @Nullable NBTTagCompound tileEntityData) {
-		super(x, y, z, state, tileEntityData);
+	public PreparableBannerInfo(IBlockState state, @Nullable NBTTagCompound tileEntityData) {
+		super(state, tileEntityData);
 	}
 
 	@Override
@@ -47,9 +43,9 @@ public class PreparableBannerInfo extends PreparableBlockInfo {
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntityBanner> tileEntitySupplier) {
 			TileEntityBanner tileEntity = tileEntitySupplier.get();
 			if (BannerHelper.isCQBanner(tileEntity)) {
-				return new PreparableBannerInfo(x, y, z, state, IFactory.writeTileEntityToNBT(tileEntity));
+				return new PreparableBannerInfo(state, IFactory.writeTileEntityToNBT(tileEntity));
 			}
-			return new PreparableBlockInfo(x, y, z, state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
+			return new PreparableBlockInfo(state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
 		}
 
 	}
@@ -74,7 +70,7 @@ public class PreparableBannerInfo extends PreparableBlockInfo {
 			if ((data & 1) == 1) {
 				tileEntityData = nbtList.getCompoundTagAt(ByteBufUtils.readVarInt(buf, 5));
 			}
-			return new PreparableBannerInfo(x, y, z, state, tileEntityData);
+			return new PreparableBannerInfo(state, tileEntityData);
 		}
 
 		@Override
@@ -86,7 +82,7 @@ public class PreparableBannerInfo extends PreparableBlockInfo {
 			if (intArray.length > 2) {
 				tileEntityData = nbtList.getCompoundTagAt(intArray[2]);
 			}
-			return new PreparableBannerInfo(x, y, z, state, tileEntityData);
+			return new PreparableBannerInfo(state, tileEntityData);
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
@@ -1,10 +1,13 @@
 package team.cqr.cqrepoured.world.structure.generation.generation.preparable;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockSkull;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
@@ -121,6 +124,10 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 	}
 
 	public static class Serializer implements ISerializer<PreparableBlockInfo> {
+		/**
+		 * Cache {@link PreparableBlockInfo} with {@link Block#getDefaultState()} and null {@code tileEntityData}
+		 */
+		private final Map<Block, PreparableBlockInfo> simpleBlockCache = new ConcurrentHashMap<>();
 
 		@Override
 		public void write(PreparableBlockInfo preparable, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
@@ -139,6 +146,9 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 			NBTTagCompound tileEntityData = null;
 			if ((data & 1) == 1) {
 				tileEntityData = nbtList.getCompoundTagAt(ByteBufUtils.readVarInt(buf, 5));
+			}
+			if (tileEntityData == null && state != null && state.equals(state.getBlock().getDefaultState())) {
+				return simpleBlockCache.computeIfAbsent(state.getBlock(), b -> new PreparableBlockInfo(b.getDefaultState(), null));
 			}
 			return new PreparableBlockInfo(state, tileEntityData);
 		}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
@@ -1,13 +1,12 @@
 package team.cqr.cqrepoured.world.structure.generation.generation.preparable;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockSkull;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
@@ -28,11 +27,20 @@ import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePa
 
 public class PreparableBlockInfo extends PreparablePosInfo {
 
+	private static final Map<IBlockState, PreparableBlockInfo> CACHE = new WeakHashMap<>();
+
+	public static PreparableBlockInfo of(IBlockState state, @Nullable NBTTagCompound tileEntityData) {
+		if (tileEntityData == null) {
+			return CACHE.computeIfAbsent(state, s -> new PreparableBlockInfo(s, null));
+		}
+		return new PreparableBlockInfo(state, tileEntityData);
+	}
+
 	private final IBlockState state;
 	@Nullable
 	private final NBTTagCompound tileEntityData;
 
-	public PreparableBlockInfo(IBlockState state, @Nullable NBTTagCompound tileEntityData) {
+	protected PreparableBlockInfo(IBlockState state, @Nullable NBTTagCompound tileEntityData) {
 		this.state = state;
 		this.tileEntityData = tileEntityData;
 	}
@@ -118,16 +126,12 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntity> tileEntitySupplier) {
-			return new PreparableBlockInfo(state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
+			return of(state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
 		}
 
 	}
 
 	public static class Serializer implements ISerializer<PreparableBlockInfo> {
-		/**
-		 * Cache {@link PreparableBlockInfo} with {@link Block#getDefaultState()} and null {@code tileEntityData}
-		 */
-		private final Map<Block, PreparableBlockInfo> simpleBlockCache = new ConcurrentHashMap<>();
 
 		@Override
 		public void write(PreparableBlockInfo preparable, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
@@ -147,10 +151,7 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 			if ((data & 1) == 1) {
 				tileEntityData = nbtList.getCompoundTagAt(ByteBufUtils.readVarInt(buf, 5));
 			}
-			if (tileEntityData == null && state != null && state.equals(state.getBlock().getDefaultState())) {
-				return simpleBlockCache.computeIfAbsent(state.getBlock(), b -> new PreparableBlockInfo(b.getDefaultState(), null));
-			}
-			return new PreparableBlockInfo(state, tileEntityData);
+			return of(state, tileEntityData);
 		}
 
 		@Override
@@ -162,7 +163,7 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 			if (intArray.length > 2) {
 				tileEntityData = nbtList.getCompoundTagAt(intArray[2]);
 			}
-			return new PreparableBlockInfo(state, tileEntityData);
+			return of(state, tileEntityData);
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
@@ -29,18 +29,13 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 	@Nullable
 	private final NBTTagCompound tileEntityData;
 
-	public PreparableBlockInfo(BlockPos pos, IBlockState state, @Nullable NBTTagCompound tileEntityData) {
-		this(pos.getX(), pos.getY(), pos.getZ(), state, tileEntityData);
-	}
-
-	public PreparableBlockInfo(int x, int y, int z, IBlockState state, @Nullable NBTTagCompound tileEntityData) {
-		super(x, y, z);
+	public PreparableBlockInfo(IBlockState state, @Nullable NBTTagCompound tileEntityData) {
 		this.state = state;
 		this.tileEntityData = tileEntityData;
 	}
 
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		IBlockState transformedState = this.state.withMirror(placement.getMirror()).withRotation(placement.getRotation());
 		TileEntity tileEntity = null;
 
@@ -120,7 +115,7 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntity> tileEntitySupplier) {
-			return new PreparableBlockInfo(x, y, z, state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
+			return new PreparableBlockInfo(state, IFactory.writeTileEntityToNBT(tileEntitySupplier.get()));
 		}
 
 	}
@@ -145,7 +140,7 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 			if ((data & 1) == 1) {
 				tileEntityData = nbtList.getCompoundTagAt(ByteBufUtils.readVarInt(buf, 5));
 			}
-			return new PreparableBlockInfo(x, y, z, state, tileEntityData);
+			return new PreparableBlockInfo(state, tileEntityData);
 		}
 
 		@Override
@@ -157,7 +152,7 @@ public class PreparableBlockInfo extends PreparablePosInfo {
 			if (intArray.length > 2) {
 				tileEntityData = nbtList.getCompoundTagAt(intArray[2]);
 			}
-			return new PreparableBlockInfo(x, y, z, state, tileEntityData);
+			return new PreparableBlockInfo(state, tileEntityData);
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBlockInfo.java
@@ -1,7 +1,7 @@
 package team.cqr.cqrepoured.world.structure.generation.generation.preparable;
 
 import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -27,7 +27,7 @@ import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePa
 
 public class PreparableBlockInfo extends PreparablePosInfo {
 
-	private static final Map<IBlockState, PreparableBlockInfo> CACHE = new WeakHashMap<>();
+	private static final Map<IBlockState, PreparableBlockInfo> CACHE = new ConcurrentHashMap<>();
 
 	public static PreparableBlockInfo of(IBlockState state, @Nullable NBTTagCompound tileEntityData) {
 		if (tileEntityData == null) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBossInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableBossInfo.java
@@ -40,20 +40,11 @@ public class PreparableBossInfo extends PreparablePosInfo {
 	@Nullable
 	private final NBTTagCompound bossTag;
 
-	public PreparableBossInfo(BlockPos pos, TileEntityBoss tileEntityBoss) {
-		this(pos.getX(), pos.getY(), pos.getZ(), tileEntityBoss);
+	public PreparableBossInfo(TileEntityBoss tileEntityBoss) {
+		this(getBossTag(tileEntityBoss));
 	}
 
-	public PreparableBossInfo(int x, int y, int z, TileEntityBoss tileEntityBoss) {
-		this(x, y, z, getBossTag(tileEntityBoss));
-	}
-
-	public PreparableBossInfo(BlockPos pos, @Nullable NBTTagCompound bossTag) {
-		this(pos.getX(), pos.getY(), pos.getZ(), bossTag);
-	}
-
-	public PreparableBossInfo(int x, int y, int z, @Nullable NBTTagCompound bossTag) {
-		super(x, y, z);
+	public PreparableBossInfo(@Nullable NBTTagCompound bossTag) {
 		this.bossTag = bossTag;
 	}
 
@@ -70,7 +61,7 @@ public class PreparableBossInfo extends PreparablePosInfo {
 	}
 
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		Entity entity;
 
 		if (this.bossTag != null) {
@@ -168,7 +159,7 @@ public class PreparableBossInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntityBoss> tileEntitySupplier) {
-			return new PreparableBossInfo(x, y, z, tileEntitySupplier.get());
+			return new PreparableBossInfo(tileEntitySupplier.get());
 		}
 
 	}
@@ -190,13 +181,13 @@ public class PreparableBossInfo extends PreparablePosInfo {
 			if ((data & 1) == 1) {
 				bossTag = nbtList.getCompoundTagAt(data >>> 1);
 			}
-			return new PreparableBossInfo(x, y, z, bossTag);
+			return new PreparableBossInfo(bossTag);
 		}
 
 		@Override
 		@Deprecated
 		public PreparableBossInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableBossInfo(x, y, z, (NBTTagCompound) null);
+			return new PreparableBossInfo((NBTTagCompound) null);
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableEmptyInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableEmptyInfo.java
@@ -18,17 +18,13 @@ import team.cqr.cqrepoured.world.structure.generation.generation.preparable.Prep
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public class PreparableEmptyInfo extends PreparablePosInfo {
+	public static final PreparableEmptyInfo INSTANCE = new PreparableEmptyInfo();
 
-	public PreparableEmptyInfo(BlockPos pos) {
-		this(pos.getX(), pos.getY(), pos.getZ());
-	}
-
-	public PreparableEmptyInfo(int x, int y, int z) {
-		super(x, y, z);
+	protected PreparableEmptyInfo() {
 	}
 
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		return null;
 	}
 
@@ -41,7 +37,7 @@ public class PreparableEmptyInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntity> tileEntitySupplier) {
-			return new PreparableEmptyInfo(x, y, z);
+			return INSTANCE;
 		}
 
 	}
@@ -55,13 +51,13 @@ public class PreparableEmptyInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparableEmptyInfo read(int x, int y, int z, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableEmptyInfo(x, y, z);
+			return INSTANCE;
 		}
 
 		@Override
 		@Deprecated
 		public PreparableEmptyInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableEmptyInfo(x, y, z);
+			return INSTANCE;
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableEmptyInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableEmptyInfo.java
@@ -18,9 +18,11 @@ import team.cqr.cqrepoured.world.structure.generation.generation.preparable.Prep
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public class PreparableEmptyInfo extends PreparablePosInfo {
+
 	public static final PreparableEmptyInfo INSTANCE = new PreparableEmptyInfo();
 
 	protected PreparableEmptyInfo() {
+
 	}
 
 	@Override

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableForceFieldNexusInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableForceFieldNexusInfo.java
@@ -19,9 +19,11 @@ import team.cqr.cqrepoured.world.structure.generation.generation.preparable.Prep
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public class PreparableForceFieldNexusInfo extends PreparablePosInfo {
+
 	public static final PreparableForceFieldNexusInfo INSTANCE = new PreparableForceFieldNexusInfo();
 
 	protected PreparableForceFieldNexusInfo() {
+
 	}
 
 	@Override

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableForceFieldNexusInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableForceFieldNexusInfo.java
@@ -20,16 +20,11 @@ import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePa
 
 public class PreparableForceFieldNexusInfo extends PreparablePosInfo {
 
-	public PreparableForceFieldNexusInfo(BlockPos pos) {
-		this(pos.getX(), pos.getY(), pos.getZ());
-	}
-
-	public PreparableForceFieldNexusInfo(int x, int y, int z) {
-		super(x, y, z);
+	public PreparableForceFieldNexusInfo() {
 	}
 
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		if (placement.getProtectedRegionBuilder() == null) {
 			return new GeneratableBlockInfo(pos, Blocks.AIR.getDefaultState(), null);
 		}
@@ -47,7 +42,7 @@ public class PreparableForceFieldNexusInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntityForceFieldNexus> tileEntitySupplier) {
-			return new PreparableForceFieldNexusInfo(x, y, z);
+			return new PreparableForceFieldNexusInfo();
 		}
 
 	}
@@ -61,13 +56,13 @@ public class PreparableForceFieldNexusInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparableForceFieldNexusInfo read(int x, int y, int z, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableForceFieldNexusInfo(x, y, z);
+			return new PreparableForceFieldNexusInfo();
 		}
 
 		@Override
 		@Deprecated
 		public PreparableForceFieldNexusInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableForceFieldNexusInfo(x, y, z);
+			return new PreparableForceFieldNexusInfo();
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableForceFieldNexusInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableForceFieldNexusInfo.java
@@ -19,8 +19,9 @@ import team.cqr.cqrepoured.world.structure.generation.generation.preparable.Prep
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public class PreparableForceFieldNexusInfo extends PreparablePosInfo {
+	public static final PreparableForceFieldNexusInfo INSTANCE = new PreparableForceFieldNexusInfo();
 
-	public PreparableForceFieldNexusInfo() {
+	protected PreparableForceFieldNexusInfo() {
 	}
 
 	@Override
@@ -42,7 +43,7 @@ public class PreparableForceFieldNexusInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntityForceFieldNexus> tileEntitySupplier) {
-			return new PreparableForceFieldNexusInfo();
+			return INSTANCE;
 		}
 
 	}
@@ -56,13 +57,13 @@ public class PreparableForceFieldNexusInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparableForceFieldNexusInfo read(int x, int y, int z, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableForceFieldNexusInfo();
+			return INSTANCE;
 		}
 
 		@Override
 		@Deprecated
 		public PreparableForceFieldNexusInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableForceFieldNexusInfo();
+			return INSTANCE;
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableLootChestInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableLootChestInfo.java
@@ -37,18 +37,13 @@ public class PreparableLootChestInfo extends PreparablePosInfo {
 	private final ResourceLocation lootTable;
 	private final EnumFacing facing;
 
-	public PreparableLootChestInfo(BlockPos pos, ResourceLocation lootTable, EnumFacing facing) {
-		this(pos.getX(), pos.getY(), pos.getZ(), lootTable, facing);
-	}
-
-	public PreparableLootChestInfo(int x, int y, int z, ResourceLocation lootTable, EnumFacing facing) {
-		super(x, y, z);
+	public PreparableLootChestInfo(ResourceLocation lootTable, EnumFacing facing) {
 		this.lootTable = lootTable;
 		this.facing = facing;
 	}
 
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		IBlockState state = Blocks.CHEST.getDefaultState().withProperty(BlockChest.FACING, this.facing);
 		state = state.withMirror(placement.getMirror()).withRotation(placement.getRotation());
 		TileEntity tileEntity = state.getBlock().createTileEntity(world, state);
@@ -88,7 +83,7 @@ public class PreparableLootChestInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntityExporterChest> tileEntitySupplier) {
-			return new PreparableLootChestInfo(x, y, z, tileEntitySupplier.get().getLootTable(), state.getValue(BlockHorizontal.FACING));
+			return new PreparableLootChestInfo(tileEntitySupplier.get().getLootTable(), state.getValue(BlockHorizontal.FACING));
 		}
 
 	}
@@ -105,7 +100,7 @@ public class PreparableLootChestInfo extends PreparablePosInfo {
 		public PreparableLootChestInfo read(int x, int y, int z, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
 			ResourceLocation lootTable = new ResourceLocation(ByteBufUtils.readUTF8String(buf));
 			EnumFacing facing = EnumFacing.byHorizontalIndex(buf.readByte());
-			return new PreparableLootChestInfo(x, y, z, lootTable, facing);
+			return new PreparableLootChestInfo(lootTable, facing);
 		}
 
 		@Override
@@ -114,7 +109,7 @@ public class PreparableLootChestInfo extends PreparablePosInfo {
 			int[] intArray = nbtIntArray.getIntArray();
 			ResourceLocation lootTable = getLootTableFromId(intArray[1]);
 			EnumFacing facing = EnumFacing.byHorizontalIndex(intArray[2]);
-			return new PreparableLootChestInfo(x, y, z, lootTable, facing);
+			return new PreparableLootChestInfo(lootTable, facing);
 		}
 
 		@Deprecated

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableMapInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableMapInfo.java
@@ -37,20 +37,11 @@ public class PreparableMapInfo extends PreparablePosInfo {
 	private final boolean fillMap;
 	private final int fillRadius;
 
-	public PreparableMapInfo(BlockPos pos, EnumFacing facing, TileEntityMap tileEntityMap) {
-		this(pos.getX(), pos.getY(), pos.getZ(), facing, tileEntityMap);
+	public PreparableMapInfo(EnumFacing facing, TileEntityMap tileEntityMap) {
+		this(facing, (byte) tileEntityMap.getScale(), tileEntityMap.getOrientation(), tileEntityMap.lockOrientation(), tileEntityMap.getOriginX(), tileEntityMap.getOriginZ(), tileEntityMap.getOffsetX(), tileEntityMap.getOffsetZ(), tileEntityMap.fillMap(), tileEntityMap.getFillRadius());
 	}
 
-	public PreparableMapInfo(int x, int y, int z, EnumFacing facing, TileEntityMap tileEntityMap) {
-		this(x, y, z, facing, (byte) tileEntityMap.getScale(), tileEntityMap.getOrientation(), tileEntityMap.lockOrientation(), tileEntityMap.getOriginX(), tileEntityMap.getOriginZ(), tileEntityMap.getOffsetX(), tileEntityMap.getOffsetZ(), tileEntityMap.fillMap(), tileEntityMap.getFillRadius());
-	}
-
-	public PreparableMapInfo(BlockPos pos, EnumFacing facing, byte scale, EnumFacing orientation, boolean lockOrientation, int originX, int originZ, int offsetX, int offsetZ, boolean fillMap, int fillRadius) {
-		this(pos.getX(), pos.getY(), pos.getZ(), facing, scale, orientation, lockOrientation, originX, originZ, offsetX, offsetZ, fillMap, fillRadius);
-	}
-
-	public PreparableMapInfo(int x, int y, int z, EnumFacing facing, byte scale, EnumFacing orientation, boolean lockOrientation, int originX, int originZ, int offsetX, int offsetZ, boolean fillMap, int fillRadius) {
-		super(x, y, z);
+	public PreparableMapInfo(EnumFacing facing, byte scale, EnumFacing orientation, boolean lockOrientation, int originX, int originZ, int offsetX, int offsetZ, boolean fillMap, int fillRadius) {
 		this.facing = facing;
 		this.scale = scale;
 		this.orientation = orientation;
@@ -64,7 +55,7 @@ public class PreparableMapInfo extends PreparablePosInfo {
 	}
 
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		EnumFacing transformedFacing = placement.getRotation().rotate(placement.getMirror().mirror(this.facing));
 		EntityItemFrame entity = new EntityItemFrame(world, pos.toImmutable(), transformedFacing);
 		switch (this.orientation) {
@@ -215,7 +206,7 @@ public class PreparableMapInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntityMap> tileEntitySupplier) {
-			return new PreparableMapInfo(x, y, z, state.getValue(BlockHorizontal.FACING), tileEntitySupplier.get());
+			return new PreparableMapInfo(state.getValue(BlockHorizontal.FACING), tileEntitySupplier.get());
 		}
 
 	}
@@ -252,7 +243,7 @@ public class PreparableMapInfo extends PreparablePosInfo {
 			byte offsetZ = compound.getByte("offsetZ");
 			boolean fillMap = compound.getBoolean("fillMap");
 			short fillRadius = compound.getShort("fillRadius");
-			return new PreparableMapInfo(x, y, z, facing, scale, orientation, lockOrientation, originX, originZ, offsetX, offsetZ, fillMap, fillRadius);
+			return new PreparableMapInfo(facing, scale, orientation, lockOrientation, originX, originZ, offsetX, offsetZ, fillMap, fillRadius);
 		}
 
 		@Override
@@ -270,7 +261,7 @@ public class PreparableMapInfo extends PreparablePosInfo {
 			byte offsetZ = compound.getByte("offsetZ");
 			boolean fillMap = compound.getBoolean("fillMap");
 			short fillRadius = compound.getShort("fillRadius");
-			return new PreparableMapInfo(x, y, z, facing, scale, orientation, lockOrientation, originX, originZ, offsetX, offsetZ, fillMap, fillRadius);
+			return new PreparableMapInfo(facing, scale, orientation, lockOrientation, originX, originZ, offsetX, offsetZ, fillMap, fillRadius);
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
@@ -28,10 +28,10 @@ import team.cqr.cqrepoured.block.BlockMapPlaceholder;
 import team.cqr.cqrepoured.block.BlockNull;
 import team.cqr.cqrepoured.block.BlockSpawner;
 import team.cqr.cqrepoured.block.BlockTNTCQR;
+import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 import team.cqr.cqrepoured.world.structure.generation.generation.DungeonPlacement;
 import team.cqr.cqrepoured.world.structure.generation.generation.generatable.GeneratablePosInfo;
 import team.cqr.cqrepoured.config.CQRConfig;
-import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public abstract class PreparablePosInfo {
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
@@ -28,10 +28,10 @@ import team.cqr.cqrepoured.block.BlockMapPlaceholder;
 import team.cqr.cqrepoured.block.BlockNull;
 import team.cqr.cqrepoured.block.BlockSpawner;
 import team.cqr.cqrepoured.block.BlockTNTCQR;
+import team.cqr.cqrepoured.config.CQRConfig;
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 import team.cqr.cqrepoured.world.structure.generation.generation.DungeonPlacement;
 import team.cqr.cqrepoured.world.structure.generation.generation.generatable.GeneratablePosInfo;
-import team.cqr.cqrepoured.config.CQRConfig;
 
 public abstract class PreparablePosInfo {
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
@@ -29,9 +29,9 @@ import team.cqr.cqrepoured.block.BlockNull;
 import team.cqr.cqrepoured.block.BlockSpawner;
 import team.cqr.cqrepoured.block.BlockTNTCQR;
 import team.cqr.cqrepoured.config.CQRConfig;
-import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 import team.cqr.cqrepoured.world.structure.generation.generation.DungeonPlacement;
 import team.cqr.cqrepoured.world.structure.generation.generation.generatable.GeneratablePosInfo;
+import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public abstract class PreparablePosInfo {
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
@@ -30,65 +30,25 @@ import team.cqr.cqrepoured.block.BlockSpawner;
 import team.cqr.cqrepoured.block.BlockTNTCQR;
 import team.cqr.cqrepoured.world.structure.generation.generation.DungeonPlacement;
 import team.cqr.cqrepoured.world.structure.generation.generation.generatable.GeneratablePosInfo;
+import team.cqr.cqrepoured.config.CQRConfig;
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
-public abstract class PreparablePosInfo implements IPreparable<GeneratablePosInfo> {
+public abstract class PreparablePosInfo {
 
-	private final int x;
-	private final int y;
-	private final int z;
-
-	protected PreparablePosInfo(int x, int y, int z) {
-		this.x = x;
-		this.y = y;
-		this.z = z;
+	protected PreparablePosInfo() {
 	}
 
-	@Override
-	public GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement) {
-		BlockPos pos = placement.transform(this.x, this.y, this.z);
+	public final GeneratablePosInfo prepare(World world, DungeonPlacement placement, int x, int y, int z) {
+		BlockPos pos = placement.transform(x, y, z);
 		if (world.isOutsideBuildHeight(pos)) {
 			return null;
 		}
-		return this.prepare(world, placement, pos);
+		return CQRConfig.advanced.structureImportMode ? this.prepareDebug(world, placement, pos) : this.prepareNormal(world, placement, pos);
 	}
 
-	@Override
-	public GeneratablePosInfo prepareDebug(World world, DungeonPlacement placement) {
-		BlockPos pos = placement.transform(this.x, this.y, this.z);
-		if (world.isOutsideBuildHeight(pos)) {
-			return null;
-		}
-		return this.prepareDebug(world, placement, pos);
-	}
-
-	protected abstract GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos);
+	protected abstract GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos);
 
 	protected abstract GeneratablePosInfo prepareDebug(World world, DungeonPlacement placement, BlockPos pos);
-
-	public int getX() {
-		return this.x;
-	}
-
-	public int getY() {
-		return this.y;
-	}
-
-	public int getZ() {
-		return this.z;
-	}
-
-	public int getChunkX() {
-		return this.x >> 4;
-	}
-
-	public int getChunkY() {
-		return this.y >> 4;
-	}
-
-	public int getChunkZ() {
-		return this.z >> 4;
-	}
 
 	public static class Registry {
 
@@ -212,7 +172,7 @@ public abstract class PreparablePosInfo implements IPreparable<GeneratablePosInf
 		public static PreparablePosInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList compoundList) {
 			int[] intArray = nbtIntArray.getIntArray();
 			if (intArray.length == 0) {
-				return new PreparableEmptyInfo(x, y, z);
+				return PreparableEmptyInfo.INSTANCE;
 			}
 			byte id = (byte) (intArray[0] + 1);
 			if (!ID_2_SERIALIZER.containsKey(id)) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparablePosInfo.java
@@ -36,6 +36,7 @@ import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePa
 public abstract class PreparablePosInfo {
 
 	protected PreparablePosInfo() {
+
 	}
 
 	public final GeneratablePosInfo prepare(World world, DungeonPlacement placement, int x, int y, int z) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableSpawnerInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableSpawnerInfo.java
@@ -44,29 +44,16 @@ public class PreparableSpawnerInfo extends PreparablePosInfo {
 
 	private final NBTTagCompound tileEntityData;
 
-	public PreparableSpawnerInfo(BlockPos pos, NBTTagCompound tileEntityData) {
-		this(pos.getX(), pos.getY(), pos.getZ(), tileEntityData);
-	}
-
-	public PreparableSpawnerInfo(int x, int y, int z, NBTTagCompound tileEntityData) {
-		super(x, y, z);
+	public PreparableSpawnerInfo(NBTTagCompound tileEntityData) {
 		this.tileEntityData = tileEntityData;
 	}
 
-	public PreparableSpawnerInfo(BlockPos pos, Collection<Entity> entities) {
-		this(pos.getX(), pos.getY(), pos.getZ(), getNBTTagCompoundFromEntityList(entities.toArray(new Entity[0])));
+	public PreparableSpawnerInfo(Collection<Entity> entities) {
+		this(getNBTTagCompoundFromEntityList(entities.toArray(new Entity[0])));
 	}
 
-	public PreparableSpawnerInfo(int x, int y, int z, Collection<Entity> entities) {
-		this(x, y, z, getNBTTagCompoundFromEntityList(entities.toArray(new Entity[0])));
-	}
-
-	public PreparableSpawnerInfo(BlockPos pos, Entity... entities) {
-		this(pos.getX(), pos.getY(), pos.getZ(), getNBTTagCompoundFromEntityList(entities));
-	}
-
-	public PreparableSpawnerInfo(int x, int y, int z, Entity... entities) {
-		this(x, y, z, getNBTTagCompoundFromEntityList(entities));
+	public PreparableSpawnerInfo(Entity... entities) {
+		this(getNBTTagCompoundFromEntityList(entities));
 	}
 
 	private static NBTTagCompound getNBTTagCompoundFromEntityList(Entity... entities) {
@@ -80,7 +67,7 @@ public class PreparableSpawnerInfo extends PreparablePosInfo {
 	}
 
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		IBlockState state;
 		TileEntity tileEntity;
 		BlockPos p = pos.toImmutable();
@@ -265,7 +252,7 @@ public class PreparableSpawnerInfo extends PreparablePosInfo {
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntitySpawner> tileEntitySupplier) {
 			TileEntitySpawner tileEntity = tileEntitySupplier.get();
-			return new PreparableSpawnerInfo(x, y, z, getNBTFromTileEntity(world, tileEntity.getPos(), tileEntity));
+			return new PreparableSpawnerInfo(getNBTFromTileEntity(world, tileEntity.getPos(), tileEntity));
 		}
 
 		private static NBTTagCompound getNBTFromTileEntity(World world, BlockPos pos, TileEntitySpawner tileEntity) {
@@ -317,7 +304,7 @@ public class PreparableSpawnerInfo extends PreparablePosInfo {
 		@Override
 		public PreparableSpawnerInfo read(int x, int y, int z, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
 			NBTTagCompound tileEntityData = nbtList.getCompoundTagAt(ByteBufUtils.readVarInt(buf, 5));
-			return new PreparableSpawnerInfo(x, y, z, tileEntityData);
+			return new PreparableSpawnerInfo(tileEntityData);
 		}
 
 		@Override
@@ -325,7 +312,7 @@ public class PreparableSpawnerInfo extends PreparablePosInfo {
 		public PreparableSpawnerInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList nbtList) {
 			int[] intArray = nbtIntArray.getIntArray();
 			NBTTagCompound tileEntityData = nbtList.getCompoundTagAt(intArray[2]);
-			return new PreparableSpawnerInfo(x, y, z, tileEntityData);
+			return new PreparableSpawnerInfo(tileEntityData);
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableTNTCQRInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableTNTCQRInfo.java
@@ -19,6 +19,10 @@ import team.cqr.cqrepoured.world.structure.generation.generation.preparable.Prep
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public class PreparableTNTCQRInfo extends PreparablePosInfo {
+	public static final PreparableTNTCQRInfo INSTANCE = new PreparableTNTCQRInfo();
+
+	protected PreparableTNTCQRInfo() {
+	}
 
 	@Override
 	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
@@ -34,7 +38,7 @@ public class PreparableTNTCQRInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntity> tileEntitySupplier) {
-			return new PreparableTNTCQRInfo();
+			return INSTANCE;
 		}
 
 	}
@@ -48,13 +52,13 @@ public class PreparableTNTCQRInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparableTNTCQRInfo read(int x, int y, int z, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableTNTCQRInfo();
+			return INSTANCE;
 		}
 
 		@Override
 		@Deprecated
 		public PreparableTNTCQRInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableTNTCQRInfo();
+			return INSTANCE;
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableTNTCQRInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableTNTCQRInfo.java
@@ -19,9 +19,11 @@ import team.cqr.cqrepoured.world.structure.generation.generation.preparable.Prep
 import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePalette;
 
 public class PreparableTNTCQRInfo extends PreparablePosInfo {
+
 	public static final PreparableTNTCQRInfo INSTANCE = new PreparableTNTCQRInfo();
 
 	protected PreparableTNTCQRInfo() {
+
 	}
 
 	@Override

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableTNTCQRInfo.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/preparable/PreparableTNTCQRInfo.java
@@ -20,12 +20,8 @@ import team.cqr.cqrepoured.world.structure.generation.structurefile.BlockStatePa
 
 public class PreparableTNTCQRInfo extends PreparablePosInfo {
 
-	public PreparableTNTCQRInfo(int x, int y, int z) {
-		super(x, y, z);
-	}
-
 	@Override
-	protected GeneratablePosInfo prepare(World world, DungeonPlacement placement, BlockPos pos) {
+	protected GeneratablePosInfo prepareNormal(World world, DungeonPlacement placement, BlockPos pos) {
 		return new GeneratableBlockInfo(pos, CQRBlocks.TNT.getDefaultState().withProperty(BlockTNTCQR.HIDDEN, true), null);
 	}
 
@@ -38,7 +34,7 @@ public class PreparableTNTCQRInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparablePosInfo create(World world, int x, int y, int z, IBlockState state, Supplier<TileEntity> tileEntitySupplier) {
-			return new PreparableTNTCQRInfo(x, y, z);
+			return new PreparableTNTCQRInfo();
 		}
 
 	}
@@ -52,13 +48,13 @@ public class PreparableTNTCQRInfo extends PreparablePosInfo {
 
 		@Override
 		public PreparableTNTCQRInfo read(int x, int y, int z, ByteBuf buf, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableTNTCQRInfo(x, y, z);
+			return new PreparableTNTCQRInfo();
 		}
 
 		@Override
 		@Deprecated
 		public PreparableTNTCQRInfo read(int x, int y, int z, NBTTagIntArray nbtIntArray, BlockStatePalette palette, NBTTagList nbtList) {
-			return new PreparableTNTCQRInfo(x, y, z);
+			return new PreparableTNTCQRInfo();
 		}
 
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorGridCity.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorGridCity.java
@@ -197,7 +197,7 @@ public class GeneratorGridCity extends AbstractDungeonGenerator<DungeonGridCity>
 
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : this.blockMap.entrySet()) {
-			partBuilder.add(new PreparableBlockInfo(entry.getKey().subtract(this.pos), entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.pos), new PreparableBlockInfo(entry.getValue(), null));
 		}
 		this.dungeonBuilder.add(partBuilder);
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorGridCity.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorGridCity.java
@@ -197,7 +197,7 @@ public class GeneratorGridCity extends AbstractDungeonGenerator<DungeonGridCity>
 
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : this.blockMap.entrySet()) {
-			partBuilder.add(entry.getKey().subtract(this.pos), new PreparableBlockInfo(entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.pos), PreparableBlockInfo.of(entry.getValue(), null));
 		}
 		this.dungeonBuilder.add(partBuilder);
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorRandomizedCastle.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorRandomizedCastle.java
@@ -66,8 +66,8 @@ public class GeneratorRandomizedCastle extends AbstractDungeonGenerator<DungeonR
 		DungeonInhabitant mobType = DungeonInhabitantManager.instance().getInhabitantByDistanceIfDefault(this.dungeon.getDungeonMob(), this.world, this.pos.getX(), this.pos.getZ());
 		this.roomHelper.generate(this.world, genArray, this.dungeon, this.pos, bossUuids, mobType);
 
-		this.dungeonBuilder.add(new BlockDungeonPart.Builder().addAll(genArray.getMainMap().values()), this.structurePos);
-		this.dungeonBuilder.add(new BlockDungeonPart.Builder().addAll(genArray.getPostMap().values()), this.structurePos);
+		this.dungeonBuilder.add(new BlockDungeonPart.Builder().addAll(genArray.getMainMap()), this.structurePos);
+		this.dungeonBuilder.add(new BlockDungeonPart.Builder().addAll(genArray.getPostMap()), this.structurePos);
 		this.dungeonBuilder.add(new EntityDungeonPart.Builder().addAll(genArray.getEntityMap()), this.structurePos);
 	}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorVegetatedCave.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorVegetatedCave.java
@@ -101,7 +101,7 @@ public class GeneratorVegetatedCave extends AbstractDungeonGenerator<DungeonVege
 		// Build
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : this.blocks.entrySet()) {
-			partBuilder.add(new PreparableBlockInfo(entry.getKey().subtract(this.pos), entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.pos), new PreparableBlockInfo(entry.getValue(), null));
 		}
 		this.dungeonBuilder.add(partBuilder);
 	}
@@ -170,7 +170,7 @@ public class GeneratorVegetatedCave extends AbstractDungeonGenerator<DungeonVege
 		}
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-			partBuilder.add(new PreparableBlockInfo(entry.getKey().subtract(this.pos), entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.pos), new PreparableBlockInfo(entry.getValue(), null));
 		}
 		this.dungeonBuilder.add(partBuilder);
 
@@ -198,7 +198,7 @@ public class GeneratorVegetatedCave extends AbstractDungeonGenerator<DungeonVege
 			}
 
 			NBTTagCompound nbt = chest.writeToNBT(new NBTTagCompound());
-			partBuilder.add(new PreparableBlockInfo(chestpos.subtract(this.pos), state, nbt));
+			partBuilder.add(chestpos.subtract(this.pos), new PreparableBlockInfo(state, nbt));
 		}
 		this.dungeonBuilder.add(partBuilder);
 	}
@@ -217,7 +217,7 @@ public class GeneratorVegetatedCave extends AbstractDungeonGenerator<DungeonVege
 				int floor = this.random.nextInt(FLOORS);
 				entityList.add(mobFactory.getGearedEntityByFloor(floor, this.world));
 			}
-			partBuilder.add(new PreparableSpawnerInfo(spawnerpos.subtract(this.pos), entityList));
+			partBuilder.add(spawnerpos.subtract(this.pos), new PreparableSpawnerInfo(entityList));
 		}
 		this.dungeonBuilder.add(partBuilder);
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorVegetatedCave.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/GeneratorVegetatedCave.java
@@ -101,7 +101,7 @@ public class GeneratorVegetatedCave extends AbstractDungeonGenerator<DungeonVege
 		// Build
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : this.blocks.entrySet()) {
-			partBuilder.add(entry.getKey().subtract(this.pos), new PreparableBlockInfo(entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.pos), PreparableBlockInfo.of(entry.getValue(), null));
 		}
 		this.dungeonBuilder.add(partBuilder);
 	}
@@ -170,7 +170,7 @@ public class GeneratorVegetatedCave extends AbstractDungeonGenerator<DungeonVege
 		}
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-			partBuilder.add(entry.getKey().subtract(this.pos), new PreparableBlockInfo(entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.pos), PreparableBlockInfo.of(entry.getValue(), null));
 		}
 		this.dungeonBuilder.add(partBuilder);
 
@@ -198,7 +198,7 @@ public class GeneratorVegetatedCave extends AbstractDungeonGenerator<DungeonVege
 			}
 
 			NBTTagCompound nbt = chest.writeToNBT(new NBTTagCompound());
-			partBuilder.add(chestpos.subtract(this.pos), new PreparableBlockInfo(state, nbt));
+			partBuilder.add(chestpos.subtract(this.pos), PreparableBlockInfo.of(state, nbt));
 		}
 		this.dungeonBuilder.add(partBuilder);
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/castleparts/rooms/CastleRoomRoofBossMain.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/castleparts/rooms/CastleRoomRoofBossMain.java
@@ -76,7 +76,7 @@ public class CastleRoomRoofBossMain extends CastleRoomBase {
 	@Override
 	public void placeBoss(World world, BlockStateGenArray genArray, DungeonRandomizedCastle dungeon, ResourceLocation bossResourceLocation, List<String> bossUuids) {
 		BlockPos pos = this.getBossRoomBuildStartPosition().add(BOSS_ROOM_STATIC_SIZE / 2, 1, BOSS_ROOM_STATIC_SIZE / 2);
-		genArray.addInternal(BlockStateGenArray.GenerationPhase.POST, new PreparableBossInfo(pos, (NBTTagCompound) null), BlockStateGenArray.EnumPriority.MEDIUM);
+		genArray.addInternal(BlockStateGenArray.GenerationPhase.POST, pos, new PreparableBossInfo((NBTTagCompound) null), BlockStateGenArray.EnumPriority.MEDIUM);
 	}
 
 	private void placeTorches(BlockPos nwCorner, BlockStateGenArray genArray) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/hangingcity/HangingCityBuilding.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/hangingcity/HangingCityBuilding.java
@@ -164,7 +164,7 @@ public class HangingCityBuilding extends AbstractDungeonGenerationComponent<Gene
 
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-			partBuilder.add(entry.getKey().subtract(center), new PreparableBlockInfo(entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(center), PreparableBlockInfo.of(entry.getValue(), null));
 		}
 		dungeonBuilder.add(partBuilder, center);
 	}
@@ -219,7 +219,7 @@ public class HangingCityBuilding extends AbstractDungeonGenerationComponent<Gene
 
 				BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 				for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-					partBuilder.add(entry.getKey().subtract(this.generator.getPos()), new PreparableBlockInfo(entry.getValue(), null));
+					partBuilder.add(entry.getKey().subtract(this.generator.getPos()), PreparableBlockInfo.of(entry.getValue(), null));
 				}
 				dungeonBuilder.add(partBuilder, this.generator.getPos());
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/hangingcity/HangingCityBuilding.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/hangingcity/HangingCityBuilding.java
@@ -164,7 +164,7 @@ public class HangingCityBuilding extends AbstractDungeonGenerationComponent<Gene
 
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-			partBuilder.add(new PreparableBlockInfo(entry.getKey().subtract(center), entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(center), new PreparableBlockInfo(entry.getValue(), null));
 		}
 		dungeonBuilder.add(partBuilder, center);
 	}
@@ -219,7 +219,7 @@ public class HangingCityBuilding extends AbstractDungeonGenerationComponent<Gene
 
 				BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 				for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-					partBuilder.add(new PreparableBlockInfo(entry.getKey().subtract(this.generator.getPos()), entry.getValue(), null));
+					partBuilder.add(entry.getKey().subtract(this.generator.getPos()), new PreparableBlockInfo(entry.getValue(), null));
 				}
 				dungeonBuilder.add(partBuilder, this.generator.getPos());
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/open/StrongholdFloorOpen.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/open/StrongholdFloorOpen.java
@@ -194,7 +194,7 @@ public class StrongholdFloorOpen extends AbstractDungeonGenerationComponent<Gene
 
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-			partBuilder.add(new PreparableBlockInfo(entry.getKey().subtract(this.generator.getPos()), entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.generator.getPos()), new PreparableBlockInfo(entry.getValue(), null));
 		}
 		dungeonBuilder.add(partBuilder);
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/open/StrongholdFloorOpen.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/open/StrongholdFloorOpen.java
@@ -194,7 +194,7 @@ public class StrongholdFloorOpen extends AbstractDungeonGenerationComponent<Gene
 
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		for (Map.Entry<BlockPos, IBlockState> entry : stateMap.entrySet()) {
-			partBuilder.add(entry.getKey().subtract(this.generator.getPos()), new PreparableBlockInfo(entry.getValue(), null));
+			partBuilder.add(entry.getKey().subtract(this.generator.getPos()), PreparableBlockInfo.of(entry.getValue(), null));
 		}
 		dungeonBuilder.add(partBuilder);
 	}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/spiral/EntranceBuilderHelper.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/spiral/EntranceBuilderHelper.java
@@ -65,28 +65,28 @@ public class EntranceBuilderHelper {
 		}
 		if (corner1 != null && corner2 != null && pillar1 != null && pillar2 != null) {
 			/*
-			 * for (BlockPos airPos : BlockPos.getAllInBox(air1, air2)) { blockInfoList.add(new PreparableBlockInfo(airPos,
+			 * for (BlockPos airPos : BlockPos.getAllInBox(air1, air2)) { blockInfoList.add(PreparableBlockInfo.of(airPos,
 			 * Blocks.AIR.getDefaultState(), null)); }
 			 */
-			BlockPos.getAllInBox(corner1, corner2.add(0, 6, 0)).forEach(t -> partBuilder.add(t, new PreparableBlockInfo(Blocks.AIR.getDefaultState(), null)));
+			BlockPos.getAllInBox(corner1, corner2.add(0, 6, 0)).forEach(t -> partBuilder.add(t, PreparableBlockInfo.of(Blocks.AIR.getDefaultState(), null)));
 
 			buildFloorAndCeiling(corner1, corner2, 5, partBuilder);
 
 			// Left torch -> Facing side: rotate right (90.0°)
 			buildPillar(pillar1, partBuilder);
-			partBuilder.add(torch1, new PreparableBlockInfo(CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.COUNTERCLOCKWISE_90)), null));
+			partBuilder.add(torch1, PreparableBlockInfo.of(CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.COUNTERCLOCKWISE_90)), null));
 			// Right torch -> Facing side: rotate left (-90.0°)
 			buildPillar(pillar2, partBuilder);
-			partBuilder.add(torch2, new PreparableBlockInfo(CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.CLOCKWISE_90)), null));
+			partBuilder.add(torch2, PreparableBlockInfo.of(CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.CLOCKWISE_90)), null));
 		}
 	}
 
 	private static void buildPillar(BlockPos bottom, BlockDungeonPart.Builder partBuilder) {
 		for (int iY = 1; iY <= 4; iY++) {
 			BlockPos pos = bottom.add(0, iY, 0);
-			partBuilder.add(pos, new PreparableBlockInfo(CQRBlocks.GRANITE_PILLAR.getDefaultState().withProperty(BlockRotatedPillar.AXIS, EnumFacing.Axis.Y), null));
+			partBuilder.add(pos, PreparableBlockInfo.of(CQRBlocks.GRANITE_PILLAR.getDefaultState().withProperty(BlockRotatedPillar.AXIS, EnumFacing.Axis.Y), null));
 		}
-		partBuilder.add(bottom.add(0, 5, 0), new PreparableBlockInfo(CQRBlocks.GRANITE_CARVED.getDefaultState(), null));
+		partBuilder.add(bottom.add(0, 5, 0), PreparableBlockInfo.of(CQRBlocks.GRANITE_CARVED.getDefaultState(), null));
 	}
 
 	private static void buildFloorAndCeiling(BlockPos start, BlockPos end, int ceilingHeight, BlockDungeonPart.Builder partBuilder) {
@@ -94,12 +94,12 @@ public class EntranceBuilderHelper {
 
 		// Floor
 		for (BlockPos p : BlockPos.getAllInBox(start, endP)) {
-			partBuilder.add(p, new PreparableBlockInfo(CQRBlocks.GRANITE_SMALL.getDefaultState(), null));
+			partBuilder.add(p, PreparableBlockInfo.of(CQRBlocks.GRANITE_SMALL.getDefaultState(), null));
 		}
 
 		// Ceiling
 		for (BlockPos p : BlockPos.getAllInBox(start.add(0, ceilingHeight + 1, 0), endP.add(0, ceilingHeight + 1, 0))) {
-			partBuilder.add(p, new PreparableBlockInfo(CQRBlocks.GRANITE_SQUARE.getDefaultState(), null));
+			partBuilder.add(p, PreparableBlockInfo.of(CQRBlocks.GRANITE_SQUARE.getDefaultState(), null));
 		}
 	}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/spiral/EntranceBuilderHelper.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/spiral/EntranceBuilderHelper.java
@@ -68,25 +68,25 @@ public class EntranceBuilderHelper {
 			 * for (BlockPos airPos : BlockPos.getAllInBox(air1, air2)) { blockInfoList.add(new PreparableBlockInfo(airPos,
 			 * Blocks.AIR.getDefaultState(), null)); }
 			 */
-			BlockPos.getAllInBox(corner1, corner2.add(0, 6, 0)).forEach(t -> partBuilder.add(new PreparableBlockInfo(t, Blocks.AIR.getDefaultState(), null)));
+			BlockPos.getAllInBox(corner1, corner2.add(0, 6, 0)).forEach(t -> partBuilder.add(t, new PreparableBlockInfo(Blocks.AIR.getDefaultState(), null)));
 
 			buildFloorAndCeiling(corner1, corner2, 5, partBuilder);
 
 			// Left torch -> Facing side: rotate right (90.0°)
 			buildPillar(pillar1, partBuilder);
-			partBuilder.add(new PreparableBlockInfo(torch1, CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.COUNTERCLOCKWISE_90)), null));
+			partBuilder.add(torch1, new PreparableBlockInfo(CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.COUNTERCLOCKWISE_90)), null));
 			// Right torch -> Facing side: rotate left (-90.0°)
 			buildPillar(pillar2, partBuilder);
-			partBuilder.add(new PreparableBlockInfo(torch2, CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.CLOCKWISE_90)), null));
+			partBuilder.add(torch2, new PreparableBlockInfo(CQRBlocks.UNLIT_TORCH.getDefaultState().withProperty(BlockTorch.FACING, StairCaseHelper.getFacingWithRotation(direction, Rotation.CLOCKWISE_90)), null));
 		}
 	}
 
 	private static void buildPillar(BlockPos bottom, BlockDungeonPart.Builder partBuilder) {
 		for (int iY = 1; iY <= 4; iY++) {
 			BlockPos pos = bottom.add(0, iY, 0);
-			partBuilder.add(new PreparableBlockInfo(pos, CQRBlocks.GRANITE_PILLAR.getDefaultState().withProperty(BlockRotatedPillar.AXIS, EnumFacing.Axis.Y), null));
+			partBuilder.add(pos, new PreparableBlockInfo(CQRBlocks.GRANITE_PILLAR.getDefaultState().withProperty(BlockRotatedPillar.AXIS, EnumFacing.Axis.Y), null));
 		}
-		partBuilder.add(new PreparableBlockInfo(bottom.add(0, 5, 0), CQRBlocks.GRANITE_CARVED.getDefaultState(), null));
+		partBuilder.add(bottom.add(0, 5, 0), new PreparableBlockInfo(CQRBlocks.GRANITE_CARVED.getDefaultState(), null));
 	}
 
 	private static void buildFloorAndCeiling(BlockPos start, BlockPos end, int ceilingHeight, BlockDungeonPart.Builder partBuilder) {
@@ -94,12 +94,12 @@ public class EntranceBuilderHelper {
 
 		// Floor
 		for (BlockPos p : BlockPos.getAllInBox(start, endP)) {
-			partBuilder.add(new PreparableBlockInfo(p, CQRBlocks.GRANITE_SMALL.getDefaultState(), null));
+			partBuilder.add(p, new PreparableBlockInfo(CQRBlocks.GRANITE_SMALL.getDefaultState(), null));
 		}
 
 		// Ceiling
 		for (BlockPos p : BlockPos.getAllInBox(start.add(0, ceilingHeight + 1, 0), endP.add(0, ceilingHeight + 1, 0))) {
-			partBuilder.add(new PreparableBlockInfo(p, CQRBlocks.GRANITE_SQUARE.getDefaultState(), null));
+			partBuilder.add(p, new PreparableBlockInfo(CQRBlocks.GRANITE_SQUARE.getDefaultState(), null));
 		}
 	}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/volcano/GeneratorVolcano.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/volcano/GeneratorVolcano.java
@@ -309,7 +309,7 @@ public class GeneratorVolcano extends AbstractDungeonGenerator<DungeonVolcano> {
 			for (int j = 0; j < blocks[i].length; j++) {
 				for (int k = 0; k < blocks[i][j].length; k++) {
 					if (blocks[i][j][k] != null) {
-						partBuilder.add(i, j, k, new PreparableBlockInfo(blocks[i][j][k], null));
+						partBuilder.add(i, j, k, PreparableBlockInfo.of(blocks[i][j][k], null));
 					}
 				}
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/volcano/GeneratorVolcano.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/volcano/GeneratorVolcano.java
@@ -309,7 +309,7 @@ public class GeneratorVolcano extends AbstractDungeonGenerator<DungeonVolcano> {
 			for (int j = 0; j < blocks[i].length; j++) {
 				for (int k = 0; k < blocks[i][j].length; k++) {
 					if (blocks[i][j][k] != null) {
-						partBuilder.add(new PreparableBlockInfo(i, j, k, blocks[i][j][k], null));
+						partBuilder.add(i, j, k, new PreparableBlockInfo(blocks[i][j][k], null));
 					}
 				}
 			}
@@ -387,7 +387,7 @@ public class GeneratorVolcano extends AbstractDungeonGenerator<DungeonVolcano> {
 
 			for (BlockPos pos : spawnerAndChestList) {
 				if (this.random.nextBoolean()) {
-					partBuilder.add(new PreparableLootChestInfo(pos.getX(), pos.getY(), pos.getZ(), lootTables[this.random.nextInt(lootTables.length)], EnumFacing.NORTH));
+					partBuilder.add(pos.getX(), pos.getY(), pos.getZ(), new PreparableLootChestInfo(lootTables[this.random.nextInt(lootTables.length)], EnumFacing.NORTH));
 				}
 
 				int entityCount = 2 + this.random.nextInt(3);
@@ -395,7 +395,7 @@ public class GeneratorVolcano extends AbstractDungeonGenerator<DungeonVolcano> {
 				for (int i = 0; i < entityCount; i++) {
 					entityList.add(mobFactory.getGearedEntityByFloor(floor, this.world));
 				}
-				partBuilder.add(new PreparableSpawnerInfo(pos.getX(), pos.getY() + 1, pos.getZ(), entityList));
+				partBuilder.add(pos.getX(), pos.getY() + 1, pos.getZ(), new PreparableSpawnerInfo(entityList));
 				floor--;
 			}
 			this.dungeonBuilder.add(partBuilder);

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
@@ -244,6 +244,8 @@ public class CQStructure {
 		this.unprotectedBlockList.clear();
 		int[] intArray = compound.getIntArray("unprotectedBlockList");
 		IntStream.range(0, intArray.length / 3).mapToObj(i -> new BlockPos(intArray[i * 3], intArray[i * 3 + 1], intArray[i * 3 + 2])).forEach(this.unprotectedBlockList::add);
+
+		trimIfPossible(this.blockInfoList);
 	}
 
 	private void takeBlocksAndEntitiesFromWorld(World world, BlockPos startPos, BlockPos endPos, boolean ignoreBasicEntities, Collection<BlockPos> unprotectedBlocks) {
@@ -289,6 +291,8 @@ public class CQStructure {
 			int z = pos.getZ() - minPos.getZ();
 			this.blockInfoList.add(PreparablePosInfo.Registry.create(world, pos, x, y, z, state));
 		}
+
+		trimIfPossible(this.blockInfoList);
 	}
 
 	private void takeEntitiesFromWorld(World world, BlockPos minPos, BlockPos maxPos, boolean ignoreBasicEntities) {
@@ -435,6 +439,13 @@ public class CQStructure {
 		for (NBTBase nbt : compound.getTagList("entityInfoList", Constants.NBT.TAG_COMPOUND)) {
 			this.entityInfoList.add(new PreparableEntityInfo((NBTTagCompound) nbt));
 		}
+
+		trimIfPossible(this.blockInfoList);
 	}
 
+	private static void trimIfPossible(List<?> list) {
+		if (list instanceof ArrayList) {
+			((ArrayList<?>) list).trimToSize();
+		}
+	}
 }

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
@@ -61,7 +61,7 @@ public class CQStructure {
 	private static final Map<File, CQStructure> CACHED_STRUCTURES = new HashMap<>();
 	public static final String CQR_FILE_VERSION = "1.2.0";
 	private static final Set<ResourceLocation> SPECIAL_ENTITIES = new HashSet<>();
-	private final List<PreparablePosInfo> blockInfoList = new ArrayList<>();
+	private List<PreparablePosInfo> blockInfoList = new ArrayList<>();
 	private final List<PreparableEntityInfo> entityInfoList = new ArrayList<>();
 	private final List<BlockPos> unprotectedBlockList = new ArrayList<>();
 	private BlockPos size = BlockPos.ORIGIN;
@@ -199,7 +199,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blockInfoList.clear();
+		this.blockInfoList = new ArrayList<>(size.getX() * size.getY() * size.getZ());
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -244,8 +244,6 @@ public class CQStructure {
 		this.unprotectedBlockList.clear();
 		int[] intArray = compound.getIntArray("unprotectedBlockList");
 		IntStream.range(0, intArray.length / 3).mapToObj(i -> new BlockPos(intArray[i * 3], intArray[i * 3 + 1], intArray[i * 3 + 2])).forEach(this.unprotectedBlockList::add);
-
-		trimIfPossible(this.blockInfoList);
 	}
 
 	private void takeBlocksAndEntitiesFromWorld(World world, BlockPos startPos, BlockPos endPos, boolean ignoreBasicEntities, Collection<BlockPos> unprotectedBlocks) {
@@ -270,7 +268,7 @@ public class CQStructure {
 	}
 
 	private void takeBlocksFromWorld(World world, BlockPos minPos, BlockPos maxPos) {
-		this.blockInfoList.clear();
+		this.blockInfoList = new ArrayList<>(size.getX() * size.getY() * size.getZ());
 
 		for (MutableBlockPos pos : BlockPos.getAllInBoxMutable(minPos, maxPos)) {
 			IBlockState state = world.getBlockState(pos);
@@ -291,8 +289,6 @@ public class CQStructure {
 			int z = pos.getZ() - minPos.getZ();
 			this.blockInfoList.add(PreparablePosInfo.Registry.create(world, pos, x, y, z, state));
 		}
-
-		trimIfPossible(this.blockInfoList);
 	}
 
 	private void takeEntitiesFromWorld(World world, BlockPos minPos, BlockPos maxPos, boolean ignoreBasicEntities) {
@@ -394,7 +390,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blockInfoList.clear();
+		this.blockInfoList = new ArrayList<>(size.getX() * size.getY() * size.getZ());
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -439,13 +435,6 @@ public class CQStructure {
 		for (NBTBase nbt : compound.getTagList("entityInfoList", Constants.NBT.TAG_COMPOUND)) {
 			this.entityInfoList.add(new PreparableEntityInfo((NBTTagCompound) nbt));
 		}
-
-		trimIfPossible(this.blockInfoList);
 	}
 
-	private static void trimIfPossible(List<?> list) {
-		if (list instanceof ArrayList) {
-			((ArrayList<?>) list).trimToSize();
-		}
-	}
 }

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
@@ -61,7 +61,7 @@ public class CQStructure {
 	private static final Map<File, CQStructure> CACHED_STRUCTURES = new HashMap<>();
 	public static final String CQR_FILE_VERSION = "1.2.0";
 	private static final Set<ResourceLocation> SPECIAL_ENTITIES = new HashSet<>();
-	private List<PreparablePosInfo> blockInfoList = new ArrayList<>();
+	private List<PreparablePosInfo> blockInfoList = Collections.emptyList();
 	private final List<PreparableEntityInfo> entityInfoList = new ArrayList<>();
 	private final List<BlockPos> unprotectedBlockList = new ArrayList<>();
 	private BlockPos size = BlockPos.ORIGIN;
@@ -199,7 +199,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blockInfoList = new ArrayList<>(size.getX() * size.getY() * size.getZ());
+		this.blockInfoList = Arrays.asList(new PreparablePosInfo[this.size.getX() * this.size.getY() * this.size.getZ()]);
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -218,7 +218,7 @@ public class CQStructure {
 		for (int x = 0; x < this.size.getX(); x++) {
 			for (int y = 0; y < this.size.getY(); y++) {
 				for (int z = 0; z < this.size.getZ(); z++) {
-					this.blockInfoList.add(PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList));
+					this.blockInfoList.set(this.flattenIndex(x, y, z), PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList));
 				}
 			}
 		}
@@ -268,7 +268,7 @@ public class CQStructure {
 	}
 
 	private void takeBlocksFromWorld(World world, BlockPos minPos, BlockPos maxPos) {
-		this.blockInfoList = new ArrayList<>(size.getX() * size.getY() * size.getZ());
+		this.blockInfoList = Arrays.asList(new PreparablePosInfo[this.size.getX() * this.size.getY() * this.size.getZ()]);
 
 		for (MutableBlockPos pos : BlockPos.getAllInBoxMutable(minPos, maxPos)) {
 			IBlockState state = world.getBlockState(pos);
@@ -287,7 +287,7 @@ public class CQStructure {
 			int x = pos.getX() - minPos.getX();
 			int y = pos.getY() - minPos.getY();
 			int z = pos.getZ() - minPos.getZ();
-			this.blockInfoList.add(PreparablePosInfo.Registry.create(world, pos, x, y, z, state));
+			this.blockInfoList.set(this.flattenIndex(x, y, z), PreparablePosInfo.Registry.create(world, pos, x, y, z, state));
 		}
 	}
 
@@ -390,7 +390,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blockInfoList = new ArrayList<>(size.getX() * size.getY() * size.getZ());
+		this.blockInfoList = Arrays.asList(new PreparablePosInfo[this.size.getX() * this.size.getY() * this.size.getZ()]);
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -409,7 +409,7 @@ public class CQStructure {
 		int y = 0;
 		int z = 0;
 		for (NBTBase nbt : compound.getTagList("blockInfoList", Constants.NBT.TAG_INT_ARRAY)) {
-			this.blockInfoList.add(PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList));
+			this.blockInfoList.set(this.flattenIndex(x, y, z), PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList));
 			if (x < this.size.getX() - 1) {
 				x++;
 			} else if (y < this.size.getY() - 1) {
@@ -427,7 +427,7 @@ public class CQStructure {
 			NBTTagCompound tag = (NBTTagCompound) nbt;
 			if (tag.hasKey("blockInfo", Constants.NBT.TAG_INT_ARRAY)) {
 				NBTTagList pos = tag.getTagList("pos", Constants.NBT.TAG_INT);
-				this.blockInfoList.add(PreparablePosInfo.Registry.read(pos.getIntAt(0), pos.getIntAt(1), pos.getIntAt(2), (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList));
+				this.blockInfoList.set(this.flattenIndex(x, y, z), PreparablePosInfo.Registry.read(pos.getIntAt(0), pos.getIntAt(1), pos.getIntAt(2), (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList));
 			}
 		}
 
@@ -435,6 +435,10 @@ public class CQStructure {
 		for (NBTBase nbt : compound.getTagList("entityInfoList", Constants.NBT.TAG_COMPOUND)) {
 			this.entityInfoList.add(new PreparableEntityInfo((NBTTagCompound) nbt));
 		}
+	}
+
+	private int flattenIndex(int x, int y, int z) {
+		return (x * this.size.getY() + y) * this.size.getZ() + z;
 	}
 
 }

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -53,17 +52,17 @@ import team.cqr.cqrepoured.world.structure.generation.generation.DungeonPlacemen
 import team.cqr.cqrepoured.world.structure.generation.generation.GeneratableDungeon;
 import team.cqr.cqrepoured.world.structure.generation.generation.part.BlockDungeonPart;
 import team.cqr.cqrepoured.world.structure.generation.generation.part.EntityDungeonPart;
+import team.cqr.cqrepoured.world.structure.generation.generation.preparable.PreparableEmptyInfo;
 import team.cqr.cqrepoured.world.structure.generation.generation.preparable.PreparableEntityInfo;
 import team.cqr.cqrepoured.world.structure.generation.generation.preparable.PreparablePosInfo;
 import team.cqr.cqrepoured.world.structure.generation.inhabitants.DungeonInhabitant;
 
 public class CQStructure {
 
-	private static final Comparator<PreparablePosInfo> DEFAULT_COMPARATOR = Comparator.comparingInt(PreparablePosInfo::getX).thenComparingInt(PreparablePosInfo::getY).thenComparingInt(PreparablePosInfo::getZ);
 	private static final Map<File, CQStructure> CACHED_STRUCTURES = new HashMap<>();
 	public static final String CQR_FILE_VERSION = "1.2.0";
 	private static final Set<ResourceLocation> SPECIAL_ENTITIES = new HashSet<>();
-	private final List<PreparablePosInfo> blockInfoList = new ArrayList<>();
+	private PreparablePosInfo[][][] blocks;
 	private final List<PreparableEntityInfo> entityInfoList = new ArrayList<>();
 	private final List<BlockPos> unprotectedBlockList = new ArrayList<>();
 	private BlockPos size = BlockPos.ORIGIN;
@@ -123,7 +122,7 @@ public class CQStructure {
 	}
 
 	public boolean isEmpty() {
-		return this.blockInfoList.isEmpty() && this.entityInfoList.isEmpty();
+		return this.blocks == null && this.entityInfoList.isEmpty();
 	}
 
 	public boolean writeToFile(File file) {
@@ -168,8 +167,16 @@ public class CQStructure {
 		NBTTagList compoundList = new NBTTagList();
 
 		// Save normal blocks
-		ByteBuf buf = Unpooled.buffer(this.blockInfoList.size() * 2);
-		this.blockInfoList.forEach(preparable -> PreparablePosInfo.Registry.write(preparable, buf, palette, compoundList));
+		int blockCount = this.size.getX() * this.size.getY() * this.size.getZ();
+		ByteBuf buf = Unpooled.buffer(blockCount * 2);
+        for (int x = 0; x < this.size.getX(); x++) {
+			for (int y = 0; y < this.size.getY(); y++) {
+				for (int z = 0; z < this.size.getZ(); z++) {
+					PreparablePosInfo info = this.blocks != null ? this.blocks[x][y][z] : null;
+					PreparablePosInfo.Registry.write(info != null ? info : PreparableEmptyInfo.INSTANCE, buf, palette, compoundList);
+				}
+			}
+		}
 		compound.setByteArray("blockInfoList", Arrays.copyOf(buf.array(), buf.writerIndex()));
 
 		// Save entities
@@ -201,7 +208,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blockInfoList.clear();
+		this.blocks = new PreparablePosInfo[this.size.getX()][this.size.getY()][this.size.getZ()];
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -220,7 +227,7 @@ public class CQStructure {
 		for (int x = 0; x < this.size.getX(); x++) {
 			for (int y = 0; y < this.size.getY(); y++) {
 				for (int z = 0; z < this.size.getZ(); z++) {
-					this.blockInfoList.add(PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList));
+					this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList);
 				}
 			}
 		}
@@ -233,8 +240,7 @@ public class CQStructure {
 				int x = buf.readShort();
 				int y = buf.readShort();
 				int z = buf.readShort();
-				int index = ((x * this.size.getY()) + y) * this.size.getZ() + z;
-				this.blockInfoList.set(index, PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList));
+				this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList);
 			}
 		}
 
@@ -270,7 +276,7 @@ public class CQStructure {
 	}
 
 	private void takeBlocksFromWorld(World world, BlockPos minPos, BlockPos maxPos) {
-		this.blockInfoList.clear();
+		this.blocks = new PreparablePosInfo[this.size.getX()][this.size.getY()][this.size.getZ()];
 
 		for (MutableBlockPos pos : BlockPos.getAllInBoxMutable(minPos, maxPos)) {
 			IBlockState state = world.getBlockState(pos);
@@ -289,10 +295,8 @@ public class CQStructure {
 			int x = pos.getX() - minPos.getX();
 			int y = pos.getY() - minPos.getY();
 			int z = pos.getZ() - minPos.getZ();
-			this.blockInfoList.add(PreparablePosInfo.Registry.create(world, pos, x, y, z, state));
+			this.blocks[x][y][z] = PreparablePosInfo.Registry.create(world, pos, x, y, z, state);
 		}
-
-		this.blockInfoList.sort(DEFAULT_COMPARATOR);
 	}
 
 	private void takeEntitiesFromWorld(World world, BlockPos minPos, BlockPos maxPos, boolean ignoreBasicEntities) {
@@ -309,8 +313,8 @@ public class CQStructure {
 		}
 	}
 
-	public List<PreparablePosInfo> getBlockInfoList() {
-		return Collections.unmodifiableList(this.blockInfoList);
+	public PreparablePosInfo[][][] getBlocks() {
+		return this.blocks;
 	}
 
 	public List<PreparableEntityInfo> getEntityInfoList() {
@@ -346,7 +350,7 @@ public class CQStructure {
 	}
 
 	public void addAll(GeneratableDungeon.Builder builder, DungeonPlacement placement) {
-		builder.add(new BlockDungeonPart.Builder().addAll(this.blockInfoList), placement);
+		builder.add(new BlockDungeonPart.Builder().addAll(this.blocks, this.size), placement);
 		builder.add(new EntityDungeonPart.Builder().addAll(this.entityInfoList), placement);
 	}
 
@@ -394,7 +398,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blockInfoList.clear();
+		this.blocks = new PreparablePosInfo[this.size.getX()][this.size.getY()][this.size.getZ()];
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -413,7 +417,10 @@ public class CQStructure {
 		int y = 0;
 		int z = 0;
 		for (NBTBase nbt : compound.getTagList("blockInfoList", Constants.NBT.TAG_INT_ARRAY)) {
-			this.blockInfoList.add(PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList));
+			PreparablePosInfo info = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList);
+			if (!(info instanceof PreparableEmptyInfo)) {
+				this.blocks[x][y][z] = info;
+			}
 			if (x < this.size.getX() - 1) {
 				x++;
 			} else if (y < this.size.getY() - 1) {
@@ -425,14 +432,16 @@ public class CQStructure {
 				z++;
 			}
 		}
-		this.blockInfoList.sort(DEFAULT_COMPARATOR);
 
 		// Load special blocks
 		for (NBTBase nbt : compound.getTagList("specialBlockInfoList", Constants.NBT.TAG_COMPOUND)) {
 			NBTTagCompound tag = (NBTTagCompound) nbt;
 			if (tag.hasKey("blockInfo", Constants.NBT.TAG_INT_ARRAY)) {
 				NBTTagList pos = tag.getTagList("pos", Constants.NBT.TAG_INT);
-				this.blockInfoList.add(PreparablePosInfo.Registry.read(pos.getIntAt(0), pos.getIntAt(1), pos.getIntAt(2), (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList));
+				PreparablePosInfo info = PreparablePosInfo.Registry.read(pos.getIntAt(0), pos.getIntAt(1), pos.getIntAt(2), (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList);
+				if (!(info instanceof PreparableEmptyInfo)) {
+					this.blocks[pos.getIntAt(0)][pos.getIntAt(1)][pos.getIntAt(2)] = info;
+				}
 			}
 		}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
@@ -417,10 +417,7 @@ public class CQStructure {
 		int y = 0;
 		int z = 0;
 		for (NBTBase nbt : compound.getTagList("blockInfoList", Constants.NBT.TAG_INT_ARRAY)) {
-			PreparablePosInfo info = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList);
-			if (!(info instanceof PreparableEmptyInfo)) {
-				this.blocks[x][y][z] = info;
-			}
+            this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList);
 			if (x < this.size.getX() - 1) {
 				x++;
 			} else if (y < this.size.getY() - 1) {
@@ -438,10 +435,10 @@ public class CQStructure {
 			NBTTagCompound tag = (NBTTagCompound) nbt;
 			if (tag.hasKey("blockInfo", Constants.NBT.TAG_INT_ARRAY)) {
 				NBTTagList pos = tag.getTagList("pos", Constants.NBT.TAG_INT);
-				PreparablePosInfo info = PreparablePosInfo.Registry.read(pos.getIntAt(0), pos.getIntAt(1), pos.getIntAt(2), (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList);
-				if (!(info instanceof PreparableEmptyInfo)) {
-					this.blocks[pos.getIntAt(0)][pos.getIntAt(1)][pos.getIntAt(2)] = info;
-				}
+				x = pos.getIntAt(0);
+				y = pos.getIntAt(1);
+				z = pos.getIntAt(2);
+                this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList);
 			}
 		}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
@@ -169,7 +169,7 @@ public class CQStructure {
 		// Save normal blocks
 		int blockCount = this.size.getX() * this.size.getY() * this.size.getZ();
 		ByteBuf buf = Unpooled.buffer(blockCount * 2);
-        for (int x = 0; x < this.size.getX(); x++) {
+		for (int x = 0; x < this.size.getX(); x++) {
 			for (int y = 0; y < this.size.getY(); y++) {
 				for (int z = 0; z < this.size.getZ(); z++) {
 					PreparablePosInfo info = this.blocks != null ? this.blocks[x][y][z] : null;
@@ -417,7 +417,7 @@ public class CQStructure {
 		int y = 0;
 		int z = 0;
 		for (NBTBase nbt : compound.getTagList("blockInfoList", Constants.NBT.TAG_INT_ARRAY)) {
-            this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList);
+			this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList);
 			if (x < this.size.getX() - 1) {
 				x++;
 			} else if (y < this.size.getY() - 1) {
@@ -438,7 +438,7 @@ public class CQStructure {
 				x = pos.getIntAt(0);
 				y = pos.getIntAt(1);
 				z = pos.getIntAt(2);
-                this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList);
+				this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList);
 			}
 		}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/structurefile/CQStructure.java
@@ -52,7 +52,6 @@ import team.cqr.cqrepoured.world.structure.generation.generation.DungeonPlacemen
 import team.cqr.cqrepoured.world.structure.generation.generation.GeneratableDungeon;
 import team.cqr.cqrepoured.world.structure.generation.generation.part.BlockDungeonPart;
 import team.cqr.cqrepoured.world.structure.generation.generation.part.EntityDungeonPart;
-import team.cqr.cqrepoured.world.structure.generation.generation.preparable.PreparableEmptyInfo;
 import team.cqr.cqrepoured.world.structure.generation.generation.preparable.PreparableEntityInfo;
 import team.cqr.cqrepoured.world.structure.generation.generation.preparable.PreparablePosInfo;
 import team.cqr.cqrepoured.world.structure.generation.inhabitants.DungeonInhabitant;
@@ -62,7 +61,7 @@ public class CQStructure {
 	private static final Map<File, CQStructure> CACHED_STRUCTURES = new HashMap<>();
 	public static final String CQR_FILE_VERSION = "1.2.0";
 	private static final Set<ResourceLocation> SPECIAL_ENTITIES = new HashSet<>();
-	private PreparablePosInfo[][][] blocks;
+	private final List<PreparablePosInfo> blockInfoList = new ArrayList<>();
 	private final List<PreparableEntityInfo> entityInfoList = new ArrayList<>();
 	private final List<BlockPos> unprotectedBlockList = new ArrayList<>();
 	private BlockPos size = BlockPos.ORIGIN;
@@ -122,7 +121,7 @@ public class CQStructure {
 	}
 
 	public boolean isEmpty() {
-		return this.blocks == null && this.entityInfoList.isEmpty();
+		return this.blockInfoList.isEmpty() && this.entityInfoList.isEmpty();
 	}
 
 	public boolean writeToFile(File file) {
@@ -167,16 +166,8 @@ public class CQStructure {
 		NBTTagList compoundList = new NBTTagList();
 
 		// Save normal blocks
-		int blockCount = this.size.getX() * this.size.getY() * this.size.getZ();
-		ByteBuf buf = Unpooled.buffer(blockCount * 2);
-		for (int x = 0; x < this.size.getX(); x++) {
-			for (int y = 0; y < this.size.getY(); y++) {
-				for (int z = 0; z < this.size.getZ(); z++) {
-					PreparablePosInfo info = this.blocks != null ? this.blocks[x][y][z] : null;
-					PreparablePosInfo.Registry.write(info != null ? info : PreparableEmptyInfo.INSTANCE, buf, palette, compoundList);
-				}
-			}
-		}
+		ByteBuf buf = Unpooled.buffer(this.blockInfoList.size() * 2);
+		this.blockInfoList.forEach(preparable -> PreparablePosInfo.Registry.write(preparable, buf, palette, compoundList));
 		compound.setByteArray("blockInfoList", Arrays.copyOf(buf.array(), buf.writerIndex()));
 
 		// Save entities
@@ -208,7 +199,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blocks = new PreparablePosInfo[this.size.getX()][this.size.getY()][this.size.getZ()];
+		this.blockInfoList.clear();
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -227,7 +218,7 @@ public class CQStructure {
 		for (int x = 0; x < this.size.getX(); x++) {
 			for (int y = 0; y < this.size.getY(); y++) {
 				for (int z = 0; z < this.size.getZ(); z++) {
-					this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList);
+					this.blockInfoList.add(PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList));
 				}
 			}
 		}
@@ -240,7 +231,8 @@ public class CQStructure {
 				int x = buf.readShort();
 				int y = buf.readShort();
 				int z = buf.readShort();
-				this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList);
+				int index = ((x * this.size.getY()) + y) * this.size.getZ() + z;
+				this.blockInfoList.set(index, PreparablePosInfo.Registry.read(x, y, z, buf, blockStatePalette, compoundTagList));
 			}
 		}
 
@@ -276,7 +268,7 @@ public class CQStructure {
 	}
 
 	private void takeBlocksFromWorld(World world, BlockPos minPos, BlockPos maxPos) {
-		this.blocks = new PreparablePosInfo[this.size.getX()][this.size.getY()][this.size.getZ()];
+		this.blockInfoList.clear();
 
 		for (MutableBlockPos pos : BlockPos.getAllInBoxMutable(minPos, maxPos)) {
 			IBlockState state = world.getBlockState(pos);
@@ -295,7 +287,7 @@ public class CQStructure {
 			int x = pos.getX() - minPos.getX();
 			int y = pos.getY() - minPos.getY();
 			int z = pos.getZ() - minPos.getZ();
-			this.blocks[x][y][z] = PreparablePosInfo.Registry.create(world, pos, x, y, z, state);
+			this.blockInfoList.add(PreparablePosInfo.Registry.create(world, pos, x, y, z, state));
 		}
 	}
 
@@ -313,8 +305,8 @@ public class CQStructure {
 		}
 	}
 
-	public PreparablePosInfo[][][] getBlocks() {
-		return this.blocks;
+	public List<PreparablePosInfo> getBlockInfoList() {
+		return Collections.unmodifiableList(this.blockInfoList);
 	}
 
 	public List<PreparableEntityInfo> getEntityInfoList() {
@@ -350,7 +342,7 @@ public class CQStructure {
 	}
 
 	public void addAll(GeneratableDungeon.Builder builder, DungeonPlacement placement) {
-		builder.add(new BlockDungeonPart.Builder().addAll(this.blocks, this.size), placement);
+		builder.add(new BlockDungeonPart.Builder().addAll(this.blockInfoList, this.size), placement);
 		builder.add(new EntityDungeonPart.Builder().addAll(this.entityInfoList), placement);
 	}
 
@@ -398,7 +390,7 @@ public class CQStructure {
 		this.author = compound.getString("author");
 		this.size = NBTUtil.getPosFromTag(compound.getCompoundTag("size"));
 
-		this.blocks = new PreparablePosInfo[this.size.getX()][this.size.getY()][this.size.getZ()];
+		this.blockInfoList.clear();
 		this.entityInfoList.clear();
 
 		BlockStatePalette blockStatePalette = new BlockStatePalette();
@@ -417,7 +409,7 @@ public class CQStructure {
 		int y = 0;
 		int z = 0;
 		for (NBTBase nbt : compound.getTagList("blockInfoList", Constants.NBT.TAG_INT_ARRAY)) {
-			this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList);
+			this.blockInfoList.add(PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) nbt, blockStatePalette, compoundTagList));
 			if (x < this.size.getX() - 1) {
 				x++;
 			} else if (y < this.size.getY() - 1) {
@@ -435,10 +427,7 @@ public class CQStructure {
 			NBTTagCompound tag = (NBTTagCompound) nbt;
 			if (tag.hasKey("blockInfo", Constants.NBT.TAG_INT_ARRAY)) {
 				NBTTagList pos = tag.getTagList("pos", Constants.NBT.TAG_INT);
-				x = pos.getIntAt(0);
-				y = pos.getIntAt(1);
-				z = pos.getIntAt(2);
-				this.blocks[x][y][z] = PreparablePosInfo.Registry.read(x, y, z, (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList);
+				this.blockInfoList.add(PreparablePosInfo.Registry.read(pos.getIntAt(0), pos.getIntAt(1), pos.getIntAt(2), (NBTTagIntArray) tag.getTag("blockInfo"), blockStatePalette, compoundTagList));
 			}
 		}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingTower.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingTower.java
@@ -38,12 +38,12 @@ public class WallPartRailingTower implements IWallPart {
 				for (int x : xValues) {
 					if (this.isBiggerPart(x)) {
 						if (y >= 3 || z == 3 || z == 12) {
-							partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2, y, z), stateBlock, null));
-							partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2 + 1, y, z), stateBlock, null));
+							partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
+							partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
 						}
 					} else if (y >= 4 && y <= 6 && (z == 3 || z == 12)) {
-						partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2, y, z), stateBlock, null));
-						partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2 + 1, y, z), stateBlock, null));
+						partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
+						partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
 					}
 				}
 			}
@@ -54,7 +54,7 @@ public class WallPartRailingTower implements IWallPart {
 			for (int z = 6; z <= 9; z++) {
 				for (int x = 4; x <= 11; x++) {
 					if (y < 9 || z == 7 || z == 8) {
-						partBuilder.add(new PreparableBlockInfo(new BlockPos(x, y, z), stateAir, null));
+						partBuilder.add(new BlockPos(x, y, z), new PreparableBlockInfo(stateAir, null));
 					}
 				}
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingTower.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingTower.java
@@ -31,6 +31,9 @@ public class WallPartRailingTower implements IWallPart {
 		IBlockState stateBlock = Blocks.DOUBLE_STONE_SLAB.getDefaultState().withProperty(BlockStoneSlab.VARIANT, BlockStoneSlab.EnumType.STONE).withProperty(BlockStoneSlab.SEAMLESS, true);
 		IBlockState stateAir = Blocks.AIR.getDefaultState();
 
+		PreparableBlockInfo stairBlock = new PreparableBlockInfo(stateBlock, null);
+		PreparableBlockInfo airBlock = new PreparableBlockInfo(stateAir, null);
+
 		int[] xValues = new int[] { 0, 1, 6, 7 };
 		int[] zValues = new int[] { 2, 3, 12, 13 };
 		for (int y = 0; y < 8; y++) {
@@ -38,12 +41,12 @@ public class WallPartRailingTower implements IWallPart {
 				for (int x : xValues) {
 					if (this.isBiggerPart(x)) {
 						if (y >= 3 || z == 3 || z == 12) {
-							partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
-							partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
+							partBuilder.add(new BlockPos(x * 2, y, z), stairBlock);
+							partBuilder.add(new BlockPos(x * 2 + 1, y, z), stairBlock);
 						}
 					} else if (y >= 4 && y <= 6 && (z == 3 || z == 12)) {
-						partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
-						partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
+						partBuilder.add(new BlockPos(x * 2, y, z), stairBlock);
+						partBuilder.add(new BlockPos(x * 2 + 1, y, z), stairBlock);
 					}
 				}
 			}
@@ -54,7 +57,7 @@ public class WallPartRailingTower implements IWallPart {
 			for (int z = 6; z <= 9; z++) {
 				for (int x = 4; x <= 11; x++) {
 					if (y < 9 || z == 7 || z == 8) {
-						partBuilder.add(new BlockPos(x, y, z), new PreparableBlockInfo(stateAir, null));
+						partBuilder.add(new BlockPos(x, y, z), airBlock);
 					}
 				}
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingTower.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingTower.java
@@ -31,8 +31,8 @@ public class WallPartRailingTower implements IWallPart {
 		IBlockState stateBlock = Blocks.DOUBLE_STONE_SLAB.getDefaultState().withProperty(BlockStoneSlab.VARIANT, BlockStoneSlab.EnumType.STONE).withProperty(BlockStoneSlab.SEAMLESS, true);
 		IBlockState stateAir = Blocks.AIR.getDefaultState();
 
-		PreparableBlockInfo stairBlock = new PreparableBlockInfo(stateBlock, null);
-		PreparableBlockInfo airBlock = new PreparableBlockInfo(stateAir, null);
+		PreparableBlockInfo stairBlock = PreparableBlockInfo.of(stateBlock, null);
+		PreparableBlockInfo airBlock = PreparableBlockInfo.of(stateAir, null);
 
 		int[] xValues = new int[] { 0, 1, 6, 7 };
 		int[] zValues = new int[] { 2, 3, 12, 13 };

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingWall.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingWall.java
@@ -52,12 +52,12 @@ public class WallPartRailingWall implements IWallPart {
 				for (int x = 0; x < 8; x++) {
 					if (this.isBiggerPart(x)) {
 						if (y >= 3 || z == 3 || z == 12) {
-							partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2, y, z), stateBlock, null));
-							partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2 + 1, y, z), stateBlock, null));
+							partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
+							partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
 						}
 					} else if (y >= 4 && y <= 6 && (z == 3 || z == 12)) {
-						partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2, y, z), stateBlock, null));
-						partBuilder.add(new PreparableBlockInfo(new BlockPos(x * 2 + 1, y, z), stateBlock, null));
+						partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
+						partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
 					}
 				}
 			}
@@ -89,7 +89,7 @@ public class WallPartRailingWall implements IWallPart {
 			TileEntitySpawner tileSpawner = (TileEntitySpawner) CQRBlocks.SPAWNER.createTileEntity(world, state2);
 			tileSpawner.inventory.setStackInSlot(0, SpawnerFactory.getSoulBottleItemStackForEntity(spawnerEnt));
 
-			partBuilder.add(new PreparableSpawnerInfo(spawnerPos, tileSpawner.writeToNBT(new NBTTagCompound())));
+			partBuilder.add(spawnerPos, new PreparableSpawnerInfo(tileSpawner.writeToNBT(new NBTTagCompound())));
 		}
 	}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingWall.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingWall.java
@@ -46,7 +46,7 @@ public class WallPartRailingWall implements IWallPart {
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		IBlockState stateBlock = Blocks.DOUBLE_STONE_SLAB.getDefaultState().withProperty(BlockStoneSlab.VARIANT, BlockStoneSlab.EnumType.STONE).withProperty(BlockStoneSlab.SEAMLESS, true);
 
-		PreparableBlockInfo stoneSlabBlock = new PreparableBlockInfo(stateBlock, null);
+		PreparableBlockInfo stoneSlabBlock = PreparableBlockInfo.of(stateBlock, null);
 
 		int[] zValues = new int[] { 2, 3, 12, 13 };
 		for (int y = 0; y < 8; y++) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingWall.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartRailingWall.java
@@ -46,18 +46,20 @@ public class WallPartRailingWall implements IWallPart {
 		BlockDungeonPart.Builder partBuilder = new BlockDungeonPart.Builder();
 		IBlockState stateBlock = Blocks.DOUBLE_STONE_SLAB.getDefaultState().withProperty(BlockStoneSlab.VARIANT, BlockStoneSlab.EnumType.STONE).withProperty(BlockStoneSlab.SEAMLESS, true);
 
+		PreparableBlockInfo stoneSlabBlock = new PreparableBlockInfo(stateBlock, null);
+
 		int[] zValues = new int[] { 2, 3, 12, 13 };
 		for (int y = 0; y < 8; y++) {
 			for (int z : zValues) {
 				for (int x = 0; x < 8; x++) {
 					if (this.isBiggerPart(x)) {
 						if (y >= 3 || z == 3 || z == 12) {
-							partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
-							partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
+							partBuilder.add(new BlockPos(x * 2, y, z), stoneSlabBlock);
+							partBuilder.add(new BlockPos(x * 2 + 1, y, z), stoneSlabBlock);
 						}
 					} else if (y >= 4 && y <= 6 && (z == 3 || z == 12)) {
-						partBuilder.add(new BlockPos(x * 2, y, z), new PreparableBlockInfo(stateBlock, null));
-						partBuilder.add(new BlockPos(x * 2 + 1, y, z), new PreparableBlockInfo(stateBlock, null));
+						partBuilder.add(new BlockPos(x * 2, y, z), stoneSlabBlock);
+						partBuilder.add(new BlockPos(x * 2 + 1, y, z), stoneSlabBlock);
 					}
 				}
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartTower.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartTower.java
@@ -33,6 +33,10 @@ public class WallPartTower implements IWallPart {
 			IBlockState stateObsidian = CQRConfig.wall.obsidianCore ? Blocks.OBSIDIAN.getDefaultState() : stateBrick;
 			IBlockState stateAndesite = Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE_SMOOTH);
 
+			PreparableBlockInfo brickBlock = new PreparableBlockInfo(stateBrick, null);
+			PreparableBlockInfo obsidianBlock = new PreparableBlockInfo(stateObsidian, null);
+			PreparableBlockInfo andesiteBlock = new PreparableBlockInfo(stateAndesite, null);
+
 			int height = this.getTopY() - startY;
 			for (BlockPos pos : BlockPos.getAllInBox(0, 0, 0, 15, height, 15)) {
 				int x = pos.getX();
@@ -43,9 +47,9 @@ public class WallPartTower implements IWallPart {
 				if ((z >= 4 && z < 12) && (x <= 4 || x >= 12)) {
 					if (y <= height - 7) {
 						if ((z >= 6 && z <= 9) && y < (height - 7)) {
-							partBuilder.add(pos, new PreparableBlockInfo(stateObsidian, null));
+							partBuilder.add(pos, obsidianBlock);
 						} else {
-							partBuilder.add(pos, new PreparableBlockInfo(stateBrick, null));
+							partBuilder.add(pos, brickBlock);
 						}
 					}
 				}
@@ -53,11 +57,11 @@ public class WallPartTower implements IWallPart {
 				// Tower itself
 				// Obsidian core
 				if (((z >= 6 && z <= 9) && (y <= height - 8)) || (((x >= 6 && x <= 9) && (z >= 2 && z <= 13)) && y < height - 7)) {
-					partBuilder.add(pos, new PreparableBlockInfo(stateObsidian, null));
+					partBuilder.add(pos, obsidianBlock);
 				} else {
 					// Wall outer blocks
 					if ((x >= 4 && x <= 11)) {
-						partBuilder.add(pos, new PreparableBlockInfo(stateAndesite, null));
+						partBuilder.add(pos, andesiteBlock);
 					}
 				}
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartTower.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartTower.java
@@ -33,9 +33,9 @@ public class WallPartTower implements IWallPart {
 			IBlockState stateObsidian = CQRConfig.wall.obsidianCore ? Blocks.OBSIDIAN.getDefaultState() : stateBrick;
 			IBlockState stateAndesite = Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE_SMOOTH);
 
-			PreparableBlockInfo brickBlock = new PreparableBlockInfo(stateBrick, null);
-			PreparableBlockInfo obsidianBlock = new PreparableBlockInfo(stateObsidian, null);
-			PreparableBlockInfo andesiteBlock = new PreparableBlockInfo(stateAndesite, null);
+			PreparableBlockInfo brickBlock = PreparableBlockInfo.of(stateBrick, null);
+			PreparableBlockInfo obsidianBlock = PreparableBlockInfo.of(stateObsidian, null);
+			PreparableBlockInfo andesiteBlock = PreparableBlockInfo.of(stateAndesite, null);
 
 			int height = this.getTopY() - startY;
 			for (BlockPos pos : BlockPos.getAllInBox(0, 0, 0, 15, height, 15)) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartTower.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartTower.java
@@ -43,9 +43,9 @@ public class WallPartTower implements IWallPart {
 				if ((z >= 4 && z < 12) && (x <= 4 || x >= 12)) {
 					if (y <= height - 7) {
 						if ((z >= 6 && z <= 9) && y < (height - 7)) {
-							partBuilder.add(new PreparableBlockInfo(pos, stateObsidian, null));
+							partBuilder.add(pos, new PreparableBlockInfo(stateObsidian, null));
 						} else {
-							partBuilder.add(new PreparableBlockInfo(pos, stateBrick, null));
+							partBuilder.add(pos, new PreparableBlockInfo(stateBrick, null));
 						}
 					}
 				}
@@ -53,11 +53,11 @@ public class WallPartTower implements IWallPart {
 				// Tower itself
 				// Obsidian core
 				if (((z >= 6 && z <= 9) && (y <= height - 8)) || (((x >= 6 && x <= 9) && (z >= 2 && z <= 13)) && y < height - 7)) {
-					partBuilder.add(new PreparableBlockInfo(pos, stateObsidian, null));
+					partBuilder.add(pos, new PreparableBlockInfo(stateObsidian, null));
 				} else {
 					// Wall outer blocks
 					if ((x >= 4 && x <= 11)) {
-						partBuilder.add(new PreparableBlockInfo(pos, stateAndesite, null));
+						partBuilder.add(pos, new PreparableBlockInfo(stateAndesite, null));
 					}
 				}
 			}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartWall.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartWall.java
@@ -36,9 +36,9 @@ public class WallPartWall implements IWallPart {
 			// Calculates all the block positions
 			for (BlockPos pos : BlockPos.getAllInBox(0, 0, 4, 15, height, 11)) {
 				if (pos.getY() < height && pos.getZ() >= 6 && pos.getZ() <= 9) {
-					partBuilder.add(new PreparableBlockInfo(pos, stateObsidian, null));
+					partBuilder.add(pos, new PreparableBlockInfo(stateObsidian, null));
 				} else {
-					partBuilder.add(new PreparableBlockInfo(pos, stateBrick, null));
+					partBuilder.add(pos, new PreparableBlockInfo(stateBrick, null));
 				}
 			}
 

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartWall.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartWall.java
@@ -32,8 +32,8 @@ public class WallPartWall implements IWallPart {
 			IBlockState stateBrick = Blocks.STONEBRICK.getDefaultState();
 			IBlockState stateObsidian = CQRConfig.wall.obsidianCore ? Blocks.OBSIDIAN.getDefaultState() : stateBrick;
 
-			PreparableBlockInfo brickBlock = new PreparableBlockInfo(stateBrick, null);
-			PreparableBlockInfo obsidianBlock = new PreparableBlockInfo(stateObsidian, null);
+			PreparableBlockInfo brickBlock = PreparableBlockInfo.of(stateBrick, null);
+			PreparableBlockInfo obsidianBlock = PreparableBlockInfo.of(stateObsidian, null);
 
 			int height = this.getTopY() - startY;
 			// Calculates all the block positions

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartWall.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/thewall/wallparts/WallPartWall.java
@@ -32,13 +32,16 @@ public class WallPartWall implements IWallPart {
 			IBlockState stateBrick = Blocks.STONEBRICK.getDefaultState();
 			IBlockState stateObsidian = CQRConfig.wall.obsidianCore ? Blocks.OBSIDIAN.getDefaultState() : stateBrick;
 
+			PreparableBlockInfo brickBlock = new PreparableBlockInfo(stateBrick, null);
+			PreparableBlockInfo obsidianBlock = new PreparableBlockInfo(stateObsidian, null);
+
 			int height = this.getTopY() - startY;
 			// Calculates all the block positions
 			for (BlockPos pos : BlockPos.getAllInBox(0, 0, 4, 15, height, 11)) {
 				if (pos.getY() < height && pos.getZ() >= 6 && pos.getZ() <= 9) {
-					partBuilder.add(pos, new PreparableBlockInfo(stateObsidian, null));
+					partBuilder.add(pos, obsidianBlock);
 				} else {
-					partBuilder.add(pos, new PreparableBlockInfo(stateBrick, null));
+					partBuilder.add(pos, brickBlock);
 				}
 			}
 


### PR DESCRIPTION
NOTE: The PR has been rewritten once to remove `Locational` usage, and simply remove xyz from `PreparableXXXInfo` instead. Descriptions below are for commits from the old PR.

This is done by extracting position-independent logic from `PreparableXXXInfo` to `PreparableXXXInfo.Locational`, and reuse `Locational` when possible. PreparableXXXInfo is still used during initialization of CQStructure, but once it's done, their `Locational` object is extracted and filled into a 3-dim array, where block position can then be inferred from 3 indexes.

I've split different parts of this optimization into multiple commits, and extra attention has been put into reducing breaking changes.

## Test

Test is performed by analyzing heapdump using VisualVM. 

Before. Two structures consuming roughly 280MB:
<img width="1619" height="307" alt="before" src="https://github.com/user-attachments/assets/8fee17d4-8522-47c3-800a-c62c64a8d639" />
<img width="1622" height="159" alt="image" src="https://github.com/user-attachments/assets/1b6fc8f0-40b7-443d-aa80-ba56bf9aa414" />


After, Two structures consuming roughly 40MB:
<img width="1594" height="313" alt="after" src="https://github.com/user-attachments/assets/cfab0966-e18d-4dad-8c3a-3ec324a7bf82" />
<img width="1531" height="148" alt="image" src="https://github.com/user-attachments/assets/f28d2b38-b7fe-4299-bfc3-3d1c3de222d6" />


I believe this can be further improved by improving caching of `PreparableBlockInfo.Location`, currently only those with default block state is cached