### PR TITLE
Setup Spotless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
     - name: executable
       run: chmod +x gradlew
 
+    - name: validate code format
+      run: ./gradlew spotlessCheck
+
     - name: build
       run: ./gradlew build
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'eclipse'
     id 'net.minecraftforge.gradle' version "${forge_gradle_version}"
     id 'org.spongepowered.mixin' version "${mixin_gradle_version}"
+    // starting from 8.1.0, spotless requires Gradle 8.1+
+    id("com.diffplug.spotless") version "8.0.0"
 }
 
 version = "${mc_version}-${mod_version}"
@@ -99,6 +101,12 @@ processResources {
 
     filesMatching('mcmod.info') {
         expand version: inputs.properties.get('version')
+    }
+}
+
+spotless {
+    java {
+        eclipse().configFile('./eclipse code style/CQR_formatter.xml')
     }
 }
 

--- a/src/main/java/team/cqr/cqrepoured/CQRMain.java
+++ b/src/main/java/team/cqr/cqrepoured/CQRMain.java
@@ -216,7 +216,7 @@ public class CQRMain {
 		ConfigBackupHandler.registerConfig(CQ_INHABITANT_FOLDER.getName(), "1.0.0");
 		ConfigBackupHandler.registerConfig(CQ_ITEM_FOLDER.getName(), "1.0.0");
 		ConfigBackupHandler.registerConfig(CQ_CUSTOM_TEXTURES_FOLDER_ROOT.getName(), "1.1.0");
-		
+
 		CQ_MIGRATED_STRUCTURE_FILES_FOLDER = new File(CQ_CONFIG_FOLDER, "_migrated_structures");
 
 		if (!CQ_CONFIG_FOLDER.exists() || CQRConfig.general.reinstallDefaultConfigs) {

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/boss/RenderCQRGiantSpider.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/boss/RenderCQRGiantSpider.java
@@ -20,7 +20,7 @@ public class RenderCQRGiantSpider extends RenderLiving<EntityCQRGiantSpider> {
 		super(rendermanagerIn, new ModelGiantSpider(), 0.0F);
 		this.addLayer(new LayerGlowingAreas<>(this, this::getEntityTexture));
 	}
-	
+
 	protected double getWidthScale(EntityCQRGiantSpider entity) {
 		return entity.getSizeVariation();
 	}

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/boss/endercalamity/RenderCQREnderCalamity.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/boss/endercalamity/RenderCQREnderCalamity.java
@@ -202,12 +202,12 @@ public class RenderCQREnderCalamity extends RenderCQREntityGeo<EntityCQREnderCal
 	protected TransformType getCameraTransformForItemAtBone(ItemStack boneItem, String boneName) {
 		return TransformType.NONE;
 	}
-	
+
 	@Override
 	protected double getWidthScale(EntityCQREnderCalamity entity) {
 		return super.getWidthScale(entity) * 2.0D;
 	}
-	
+
 	@Override
 	protected double getHeightScale(EntityCQREnderCalamity entity) {
 		return super.getHeightScale(entity) * 2.0D;

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/boss/exterminator/RenderCQRExterminator.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/boss/exterminator/RenderCQRExterminator.java
@@ -21,7 +21,7 @@ public class RenderCQRExterminator extends RenderCQREntityGeo<EntityCQRExtermina
 
 	public RenderCQRExterminator(RenderManager renderManager) {
 		super(renderManager, new ModelExterminator(MODEL_RESLOC, TEXTURE, "boss/exterminator"));
-		
+
 		this.addLayer(new LayerGlowingAreasGeo<EntityCQRExterminator>(this, this.TEXTURE_GETTER, this.MODEL_ID_GETTER));
 	}
 
@@ -48,19 +48,19 @@ public class RenderCQRExterminator extends RenderCQREntityGeo<EntityCQRExtermina
 	@Override
 	protected void preRenderItem(ItemStack item, String boneName, EntityCQRExterminator currentEntity) {
 		if (boneName.equalsIgnoreCase(HAND_IDENT_LEFT)) {
-			//move left or right (from the entity's POV, positive: Right), move up or down the arm, move above (negative) or under the arm (positive)
+			// move left or right (from the entity's POV, positive: Right), move up or down the arm, move above (negative) or under the arm (positive)
 			GlStateManager.translate(0.0, 0.0, -0.25);
-			//Since the golem is massive we need to scale it up a bit
-			
-			//Standard code from LayerHeldItem
+			// Since the golem is massive we need to scale it up a bit
+
+			// Standard code from LayerHeldItem
 			GlStateManager.rotate(-90.0F, 1.0F, 0.0F, 0.0F);
 			GlStateManager.rotate(180.0F, 0.0F, 1.0F, 0.0F);
-			if(!(item.getItem() instanceof ItemFlamethrower)) {
+			if (!(item.getItem() instanceof ItemFlamethrower)) {
 				GlStateManager.rotate(100, 1, 0, 0);
 				GlStateManager.translate(0, -0.3, -0.2);
 				GlStateManager.scale(1.25, 1.25, 1.25);
 			} else {
-				//Different scale cause flamethrower is very small
+				// Different scale cause flamethrower is very small
 				GlStateManager.scale(1.5, 1.5, 1.5);
 			}
 		}

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/IElectrocuteLayerRenderLogic.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/IElectrocuteLayerRenderLogic.java
@@ -10,7 +10,7 @@ import team.cqr.cqrepoured.client.util.ElectricFieldRenderUtil;
 import team.cqr.cqrepoured.entity.bases.AbstractEntityCQR;
 
 public interface IElectrocuteLayerRenderLogic<T extends EntityLivingBase> {
-	
+
 	public default void renderLayerLogic(T entity, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
 		if (entity instanceof AbstractEntityCQR && ((AbstractEntityCQR) entity).canPlayDeathAnimation()) {
 			return;
@@ -40,7 +40,6 @@ public interface IElectrocuteLayerRenderLogic<T extends EntityLivingBase> {
 
 				GlStateManager.pushMatrix();
 
-
 				this.performPreLineRenderPreparation();
 				GlStateManager.rotate(yaw - 180, 0, 1, 0);
 
@@ -50,7 +49,7 @@ public interface IElectrocuteLayerRenderLogic<T extends EntityLivingBase> {
 			}
 		}
 	}
-	
+
 	public default void performPreLineRenderPreparation() {
 		GlStateManager.translate(0, 1.501, 0);
 		GlStateManager.scale(-1, -1, 1);

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/LayerCrownRenderer.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/LayerCrownRenderer.java
@@ -33,7 +33,7 @@ public class LayerCrownRenderer extends LayerBipedArmor {
 		if (ItemCrown.hasCrown(entitylivingbaseIn.getItemStackFromSlot(EntityEquipmentSlot.HEAD))) {
 			super.doRenderLayer(entitylivingbaseIn, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, scale);
 		}
-		//Crown is not attached => you don't need to do anything!
+		// Crown is not attached => you don't need to do anything!
 	}
 
 	@Override

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/LayerElectrocute.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/LayerElectrocute.java
@@ -3,7 +3,7 @@ package team.cqr.cqrepoured.client.render.entity.layer;
 import net.minecraft.client.renderer.entity.layers.LayerRenderer;
 import net.minecraft.entity.EntityLivingBase;
 
-public class LayerElectrocute implements LayerRenderer<EntityLivingBase>, IElectrocuteLayerRenderLogic<EntityLivingBase>{
+public class LayerElectrocute implements LayerRenderer<EntityLivingBase>, IElectrocuteLayerRenderLogic<EntityLivingBase> {
 
 	@Override
 	public void doRenderLayer(EntityLivingBase entity, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/AbstractCQRLayerGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/AbstractCQRLayerGeo.java
@@ -10,34 +10,33 @@ import software.bernie.geckolib3.renderers.geo.GeoEntityRenderer;
 import software.bernie.geckolib3.renderers.geo.GeoLayerRenderer;
 
 public abstract class AbstractCQRLayerGeo<T extends EntityLivingBase & IAnimatable> extends GeoLayerRenderer<T> {
-	
+
 	protected final Function<T, ResourceLocation> funcGetCurrentTexture;
 	protected final Function<T, ResourceLocation> funcGetCurrentModel;
 
 	protected GeoEntityRenderer<T> geoRendererInstance;
-	
+
 	public AbstractCQRLayerGeo(GeoEntityRenderer<T> renderer, Function<T, ResourceLocation> funcGetCurrentTexture, Function<T, ResourceLocation> funcGetCurrentModel) {
 		super(renderer);
 		this.geoRendererInstance = renderer;
 		this.funcGetCurrentTexture = funcGetCurrentTexture;
 		this.funcGetCurrentModel = funcGetCurrentModel;
 	}
-	
+
 	@Override
 	public boolean shouldCombineTextures() {
 		return false;
 	}
-	
+
 	protected void reRenderCurrentModelInRenderer(T entity, float partialTicks, Color renderColor) {
 		this.entityRenderer.render(
-			this.getEntityModel().getModel(this.funcGetCurrentModel.apply(entity)), 
-			entity, 
-			partialTicks, 
-			(float) renderColor.getRed() / 255f, 
-			(float) renderColor.getBlue() / 255f,
-			(float) renderColor.getGreen() / 255f, 
-			(float) renderColor.getAlpha() / 255
-		);
+				this.getEntityModel().getModel(this.funcGetCurrentModel.apply(entity)),
+				entity,
+				partialTicks,
+				(float) renderColor.getRed() / 255f,
+				(float) renderColor.getBlue() / 255f,
+				(float) renderColor.getGreen() / 255f,
+				(float) renderColor.getAlpha() / 255);
 	}
 
 }

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerBossDeathGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerBossDeathGeo.java
@@ -12,17 +12,17 @@ import team.cqr.cqrepoured.entity.bases.AbstractEntityCQRBoss;
 public class LayerBossDeathGeo<T extends AbstractEntityCQRBoss & IAnimatable> extends AbstractCQRLayerGeo<T> {
 
 	protected final BossDeathRayHelper rayHelper;
-	
+
 	public LayerBossDeathGeo(GeoEntityRenderer<T> renderer, Function<T, ResourceLocation> funcGetCurrentTexture, Function<T, ResourceLocation> funcGetCurrentModel, int red, int green, int blue) {
 		this(renderer, funcGetCurrentTexture, funcGetCurrentModel, red, green, blue, 20F);
 	}
-	
+
 	public LayerBossDeathGeo(GeoEntityRenderer<T> renderer, Function<T, ResourceLocation> funcGetCurrentTexture, Function<T, ResourceLocation> funcGetCurrentModel, int red, int green, int blue, float raySize) {
 		super(renderer, funcGetCurrentTexture, funcGetCurrentModel);
-		
+
 		this.rayHelper = new BossDeathRayHelper(red, green, blue, raySize);
 	}
-	
+
 	protected int getAnimationTick(T entity) {
 		return entity.deathTime;
 	}
@@ -30,7 +30,7 @@ public class LayerBossDeathGeo<T extends AbstractEntityCQRBoss & IAnimatable> ex
 	@Override
 	public void render(T entitylivingbaseIn, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, Color renderColor) {
 		int ticks = this.getAnimationTick(entitylivingbaseIn);
-		if(ticks > 0) {
+		if (ticks > 0) {
 			this.rayHelper.renderRays(ticks, partialTicks);
 		}
 	}

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerElectrocuteGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerElectrocuteGeo.java
@@ -24,10 +24,10 @@ public class LayerElectrocuteGeo<T extends EntityLivingBase & IAnimatable> exten
 	public void render(T entitylivingbaseIn, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, Color renderColor) {
 		this.doRenderLayer(entitylivingbaseIn, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, headPitch);
 	}
-	
+
 	@Override
 	public void performPreLineRenderPreparation() {
-		//Fixes rotations on glib entities
+		// Fixes rotations on glib entities
 	}
 
 }

--- a/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerMagicArmorGeo.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/entity/layer/geo/LayerMagicArmorGeo.java
@@ -12,7 +12,7 @@ import software.bernie.geckolib3.renderers.geo.GeoEntityRenderer;
 import team.cqr.cqrepoured.client.render.entity.RenderCQREntityGeo;
 import team.cqr.cqrepoured.entity.bases.AbstractEntityCQR;
 
-public class LayerMagicArmorGeo<T extends AbstractEntityCQR & IAnimatable> extends AbstractCQRLayerGeo<T>{
+public class LayerMagicArmorGeo<T extends AbstractEntityCQR & IAnimatable> extends AbstractCQRLayerGeo<T> {
 
 	public LayerMagicArmorGeo(GeoEntityRenderer<T> renderer, Function<T, ResourceLocation> funcGetCurrentTexture, Function<T, ResourceLocation> funcGetCurrentModel) {
 		super(renderer, funcGetCurrentTexture, funcGetCurrentModel);
@@ -20,10 +20,10 @@ public class LayerMagicArmorGeo<T extends AbstractEntityCQR & IAnimatable> exten
 
 	@Override
 	public void render(T entity, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, Color renderColor) {
-		if(entity.isMagicArmorActive()) {
-			//TODO: Fix weird bug where the entity inflates when it is being looked at and the game gets paused!
+		if (entity.isMagicArmorActive()) {
+			// TODO: Fix weird bug where the entity inflates when it is being looked at and the game gets paused!
 			this.geoRendererInstance.bindTexture(RenderCQREntityGeo.TEXTURES_ARMOR);
-			
+
 			GlStateManager.pushMatrix();
 
 			GlStateManager.depthMask(!entity.isInvisible());

--- a/src/main/java/team/cqr/cqrepoured/client/render/projectile/RenderProjectileHookShotHook.java
+++ b/src/main/java/team/cqr/cqrepoured/client/render/projectile/RenderProjectileHookShotHook.java
@@ -72,7 +72,7 @@ public class RenderProjectileHookShotHook extends Render<ProjectileHookShotHook>
 		double x2 = x1;
 		double y2 = y1;
 		double z2 = z1;
-		if(entity.getThrower() != null) {
+		if (entity.getThrower() != null) {
 			x2 = entity.getThrower().lastTickPosX + (entity.getThrower().posX - entity.getThrower().lastTickPosX) * partialTicks;
 			y2 = entity.getThrower().lastTickPosY + (entity.getThrower().posY - entity.getThrower().lastTickPosY) * partialTicks;
 			y2 += entity.getThrower().height * 0.65D;

--- a/src/main/java/team/cqr/cqrepoured/client/util/ElectricFieldRenderUtil.java
+++ b/src/main/java/team/cqr/cqrepoured/client/util/ElectricFieldRenderUtil.java
@@ -83,7 +83,7 @@ public class ElectricFieldRenderUtil {
 
 	public static void renderElectricField(double fieldRadius, double fieldHeight, double x, double y, double z, int bolts, long seed) {
 		RANDOM.setSeed(seed);
-		
+
 		EmissiveUtil.preEmissiveTextureRendering();
 
 		// First disable tex2d and lighting, we do not use a texture and don't want to be affected by lighting
@@ -128,7 +128,7 @@ public class ElectricFieldRenderUtil {
 		GlStateManager.disableBlend();
 		GlStateManager.enableTexture2D();
 		GlStateManager.enableLighting();
-		
+
 		EmissiveUtil.postEmissiveTextureRendering();
 	}
 
@@ -141,7 +141,7 @@ public class ElectricFieldRenderUtil {
 		RANDOM.setSeed(seed);
 
 		EmissiveUtil.preEmissiveTextureRendering();
-		
+
 		// First disable tex2d and lighting, we do not use a texture and don't want to be affected by lighting
 		GlStateManager.disableTexture2D();
 		GlStateManager.disableLighting();
@@ -182,7 +182,7 @@ public class ElectricFieldRenderUtil {
 		GlStateManager.disableBlend();
 		GlStateManager.enableTexture2D();
 		GlStateManager.enableLighting();
-		
+
 		EmissiveUtil.postEmissiveTextureRendering();
 	}
 

--- a/src/main/java/team/cqr/cqrepoured/config/CQRConfig.java
+++ b/src/main/java/team/cqr/cqrepoured/config/CQRConfig.java
@@ -228,10 +228,10 @@ public class CQRConfig {
 				Blocks.DOUBLE_PLANT.getRegistryName().toString(),
 				Blocks.MOB_SPAWNER.getRegistryName().toString(),
 				Blocks.TORCH.getRegistryName().toString(),
-				"cqrepoured:unlit_torch", 
-				"cqrepoured:phylactery", 
-				"cqrepoured:force_field_nexus", 
-				"gravestone:gravestone", 
+				"cqrepoured:unlit_torch",
+				"cqrepoured:phylactery",
+				"cqrepoured:force_field_nexus",
+				"gravestone:gravestone",
 				"openblocks:grave",
 				Blocks.WHITE_SHULKER_BOX.getRegistryName().toString(),
 				Blocks.ORANGE_SHULKER_BOX.getRegistryName().toString(),
@@ -249,7 +249,7 @@ public class CQRConfig {
 				Blocks.GREEN_SHULKER_BOX.getRegistryName().toString(),
 				Blocks.RED_SHULKER_BOX.getRegistryName().toString(),
 				Blocks.BLACK_SHULKER_BOX.getRegistryName().toString(),
-			};
+		};
 
 		@Config.Comment("Blocks with a whitelisted material will be breakable despite being protected by the protection system.")
 		public String[] protectionSystemBreakableMaterialWhitelist = { "WATER", "LAVA", "PLANTS", "VINE", "FIRE", "CACTUS", "CAKE", "WEB" };
@@ -359,7 +359,7 @@ public class CQRConfig {
 		public float maxUncappedDamageForNonBossMobs = 50F;
 		public float maxUncappedDamageInMaxHPPercent = 1F;
 		public boolean disableFirePanicAI = false;
-		
+
 		public boolean enableTradeRestockOverTime = true;
 		@Config.Comment("Measured in ticks)")
 		public int tradeRestockTime = 72000; // One hour

--- a/src/main/java/team/cqr/cqrepoured/entity/ITradeRestockOverTime.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/ITradeRestockOverTime.java
@@ -10,32 +10,34 @@ import team.cqr.cqrepoured.entity.trade.Trade;
 import team.cqr.cqrepoured.entity.trade.TraderOffer;
 
 public interface ITradeRestockOverTime {
-	
+
 	public long getLastTimedRestockTime();
+
 	public void setLastTimedRestockTime(final long newValue);
 
 	public TraderOffer getTrades();
+
 	public boolean hasTrades();
-	
+
 	public default void updateTradeRestockTimer() {
-		if(CQRConfig.mobs.enableTradeRestockOverTime && this instanceof Entity) {
-			if(!this.hasTrades()) {
+		if (CQRConfig.mobs.enableTradeRestockOverTime && this instanceof Entity) {
+			if (!this.hasTrades()) {
 				return;
 			}
-			long ticksExisted = ((Entity)this).world.getTotalWorldTime();
+			long ticksExisted = ((Entity) this).world.getTotalWorldTime();
 			long lastTimed = this.getLastTimedRestockTime();
-			if(lastTimed <= 0) {
+			if (lastTimed <= 0) {
 				this.setLastTimedRestockTime(ticksExisted);
 				return;
 			}
 			final long delta = ticksExisted - lastTimed;
 			int restocks = (int) Math.floorDiv(delta, CQRConfig.mobs.tradeRestockTime);
 			restocks = Math.min(restocks, CQRConfig.mobs.maxAutoRestocksOverTime);
-			if(delta > 0 && restocks > 0) {
-				if(this.getTrades() != null) {
+			if (delta > 0 && restocks > 0) {
+				if (this.getTrades() != null) {
 					TraderOffer offer = this.getTrades();
 					List<Trade> trades = offer.getTrades().stream().filter(Trade::canRestock).collect(Collectors.toList());
-					for(int i = 0; !trades.isEmpty() && i < restocks; i++) {
+					for (int i = 0; !trades.isEmpty() && i < restocks; i++) {
 						int index = ((Entity) this).world.rand.nextInt(trades.size());
 						Trade trade = trades.get(index);
 						trade.incStock();
@@ -43,11 +45,11 @@ public interface ITradeRestockOverTime {
 							trades.remove(index);
 						}
 					}
-					
+
 				}
 				this.setLastTimedRestockTime(ticksExisted);
 			}
 		}
 	}
-	
+
 }

--- a/src/main/java/team/cqr/cqrepoured/entity/ai/boss/endercalamity/BossAIAreaLightnings.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/ai/boss/endercalamity/BossAIAreaLightnings.java
@@ -86,7 +86,7 @@ public class BossAIAreaLightnings extends AbstractBossAIEnderCalamity {
 			y += dirVec.y;
 			z += dirVec.z;
 		}
-		
+
 		EntityColoredLightningBolt entitybolt = new EntityColoredLightningBolt(this.world, x, y, z, true, false, 0.8F, 0.01F, 0.98F, 0.4F);
 		this.world.spawnEntity(entitybolt);
 	}

--- a/src/main/java/team/cqr/cqrepoured/entity/ai/boss/endercalamity/BossAISummonMinions.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/ai/boss/endercalamity/BossAISummonMinions.java
@@ -16,8 +16,8 @@ import team.cqr.cqrepoured.init.CQRItems;
 import team.cqr.cqrepoured.util.DungeonGenUtils;
 
 public class BossAISummonMinions extends AbstractBossAIEnderCalamity {
-	
-	//TODO: Change it to the following
+
+	// TODO: Change it to the following
 	// - minions spawn in multiple waves, waves begin once the previous one has been cleared
 	// - wave count = 3 + 3 * (1- boss HP percent)
 	// - entity count per wave = difficultyID * nearbyPlayers * wave
@@ -67,7 +67,7 @@ public class BossAISummonMinions extends AbstractBossAIEnderCalamity {
 		if (this.entity.getSummonedEntities().size() >= this.getMaxMinionsPerTime()) {
 			this.borderMinion = 100;
 			// Check list
-			//Returns true if there were (dead) entities removed from the list
+			// Returns true if there were (dead) entities removed from the list
 			if (this.entity.filterSummonLists()) {
 				this.borderMinion = 50;
 			}
@@ -82,14 +82,14 @@ public class BossAISummonMinions extends AbstractBossAIEnderCalamity {
 			pos = pos.add(-2 + this.entity.getRNG().nextInt(3), 0, -2 + this.entity.getRNG().nextInt(3));
 			minion.setPosition(pos.getX(), pos.getY(), pos.getZ());
 			this.entity.setSummonedEntityFaction(minion);
-			
+
 			if (DungeonGenUtils.percentageRandom(0.33, world.rand)) {
 				minion.setItemStackToExtraSlot(EntityEquipmentExtraSlot.BADGE, this.generateBadgeWithPotion());
 			}
 			minion.setItemStackToExtraSlot(EntityEquipmentExtraSlot.POTION, ItemStack.EMPTY);
-			
-			if(minion instanceof EntityCQREnderman) {
-				((EntityCQREnderman)minion).setMayTeleport(false);
+
+			if (minion instanceof EntityCQREnderman) {
+				((EntityCQREnderman) minion).setMayTeleport(false);
 			}
 			this.entity.addSummonedEntityToList(minion);
 			this.entity.tryEquipSummon(minion, this.world.rand);

--- a/src/main/java/team/cqr/cqrepoured/entity/ai/boss/gianttortoise/BossAITortoiseSpinAttack.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/ai/boss/gianttortoise/BossAITortoiseSpinAttack.java
@@ -130,7 +130,7 @@ public class BossAITortoiseSpinAttack extends AbstractCQREntityAI<EntityCQRGiant
 				this.getBoss().resetCurrentAnimationTickTime();
 				this.getBoss().setSpinning(false);
 				this.getBoss().resetSpinsBlocked();
-				//Reset the velocity
+				// Reset the velocity
 				this.movementVector = null;
 			}
 			if ((this.ignoreWallTicks <= 0 && this.getBoss().collidedHorizontally) || this.previousBlocks != this.getBoss().getSpinsBlocked()) {
@@ -161,7 +161,7 @@ public class BossAITortoiseSpinAttack extends AbstractCQREntityAI<EntityCQRGiant
 			this.getBoss().setSpinning(true);
 			this.getBoss().setCanBeStunned(false);
 			this.getBoss().setInShell(true);
-			if(this.movementVector != null) {
+			if (this.movementVector != null) {
 				this.getBoss().motionX = this.movementVector.x;
 				this.getBoss().motionZ = this.movementVector.z;
 				this.getBoss().motionY = this.entity.collidedHorizontally ? this.movementVector.y : 0.5 * this.movementVector.y;

--- a/src/main/java/team/cqr/cqrepoured/entity/bases/AbstractEntityCQR.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/bases/AbstractEntityCQR.java
@@ -595,7 +595,7 @@ public abstract class AbstractEntityCQR extends EntityCreature implements IMob, 
 
 		compound.setTag("trades", this.trades.writeToNBT(new NBTTagCompound()));
 		compound.setLong("lastTimedRestockTime", this.getLastTimedRestockTime());
-		
+
 		if (this.hasTextureOverride()) {
 			compound.setString("textureOverride", this.getTextureOverride().toString());
 		}
@@ -660,7 +660,7 @@ public abstract class AbstractEntityCQR extends EntityCreature implements IMob, 
 		}
 
 		this.trades.readFromNBT(compound.getCompoundTag("trades"));
-		if(compound.hasKey("lastTimedRestockTime", Constants.NBT.TAG_LONG)) {
+		if (compound.hasKey("lastTimedRestockTime", Constants.NBT.TAG_LONG)) {
 			this.lastTimedTradeRestock = compound.getLong("lastTimedRestockTime");
 		}
 
@@ -1223,7 +1223,7 @@ public abstract class AbstractEntityCQR extends EntityCreature implements IMob, 
 	public void setFaction(String newFac) {
 		this.setFaction(newFac, false);
 	}
-	
+
 	public void setFaction(String newFac, boolean ignoreCTS) {
 		// TODO: Update faction on client too!!
 		if (!this.world.isRemote) {
@@ -1303,9 +1303,9 @@ public abstract class AbstractEntityCQR extends EntityCreature implements IMob, 
 		this.setHealth(this.getMaxHealth());
 		this.setBaseHealthDependingOnPos(placement.getPos());
 
-		//Reset lastTimedRestockTick
+		// Reset lastTimedRestockTick
 		this.setLastTimedRestockTime(this.world.getTotalWorldTime());
-		
+
 		// Recalculate path points
 		for (Path.PathNode node : this.path.getNodes()) {
 			node.setPos(DungeonPlacement.transform(node.getPos().getX(), node.getPos().getY(), node.getPos().getZ(), BlockPos.ORIGIN, placement.getMirror(), placement.getRotation()));
@@ -1770,12 +1770,12 @@ public abstract class AbstractEntityCQR extends EntityCreature implements IMob, 
 		return this.dead || this.getHealth() < 0.01 || this.isDead || !this.isEntityAlive();
 	}
 
-	//ITradeRestockOverTime data accessors
+	// ITradeRestockOverTime data accessors
 	@Override
 	public long getLastTimedRestockTime() {
 		return this.lastTimedTradeRestock;
 	}
-	
+
 	@Override
 	public void setLastTimedRestockTime(long newValue) {
 		this.lastTimedTradeRestock = newValue;

--- a/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/EntityCQREnderCalamity.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/EntityCQREnderCalamity.java
@@ -623,7 +623,7 @@ public class EntityCQREnderCalamity extends AbstractEntityCQRBoss implements IAn
 		if (source.canHarmInCreative()) {
 			return super.attackEntityFrom(source, amount);
 		}
-		//amount /= 2;
+		// amount /= 2;
 		// Projectile attack
 		if (source.getImmediateSource() instanceof ProjectileEnergyOrb) {
 			// TODO: Hit by energy ball
@@ -810,7 +810,7 @@ public class EntityCQREnderCalamity extends AbstractEntityCQRBoss implements IAn
 				if (this.currentPhase != EEnderCalamityPhase.PHASE_ENERGY_TENNIS) {
 					this.tennisAI.calculateRemainingAttempts();
 					this.noTennisCounter++;
-					//TODO: Move to config?
+					// TODO: Move to config?
 					if (this.noTennisCounter > 5) {
 						this.switchToPhase(EEnderCalamityPhase.PHASE_ENERGY_TENNIS.getPhaseObject());
 						this.noTennisCounter = 0;
@@ -1183,14 +1183,14 @@ public class EntityCQREnderCalamity extends AbstractEntityCQRBoss implements IAn
 	@Override
 	public void tick() {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
 	public int tickTimer() {
 		return this.ticksExisted;
 	}
-	
+
 	private static ResourceLocation LOOT_DROP_LOOTTABLE = CQRLoottables.CHESTS_TREASURE;
 
 	public static void reloadLootDropLoottable() {

--- a/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/EntityCalamityCrystal.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/EntityCalamityCrystal.java
@@ -120,7 +120,7 @@ public class EntityCalamityCrystal extends Entity {
 						this.absorbedHealth += 2F;
 					}
 
-					if (this.absorbedHealth >= CQRConfig.bosses.enderCalamityHealingCrystalAbsorbAmount * MathHelper.clamp(this.world.getDifficulty().getId() + 1, 1, EnumDifficulty.values().length -1 /* Ignore peaceful*/)) {
+					if (this.absorbedHealth >= CQRConfig.bosses.enderCalamityHealingCrystalAbsorbAmount * MathHelper.clamp(this.world.getDifficulty().getId() + 1, 1, EnumDifficulty.values().length - 1 /* Ignore peaceful*/)) {
 						this.setAbsorbing(false);
 						this.currentTarget = this.owningEntity;
 						if (this.owningEntity == null) {

--- a/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/EntityCalamitySpawner.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/EntityCalamitySpawner.java
@@ -19,7 +19,7 @@ import team.cqr.cqrepoured.util.VectorUtil;
 public class EntityCalamitySpawner extends Entity {
 
 	private int timer;
-	
+
 	private String faction;
 	private float sizeScaling;
 	private double healthScaling;

--- a/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/phases/ECPhaseStunned.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/boss/endercalamity/phases/ECPhaseStunned.java
@@ -32,7 +32,7 @@ public class ECPhaseStunned implements IEnderCalamityPhase {
 
 	@Override
 	public IEnderCalamityPhase[] getPossibleSuccessors() {
-		//return new IEnderCalamityPhase[] { EEnderCalamityPhase.PHASE_TELEPORT_LASER.getPhaseObject(), EEnderCalamityPhase.PHASE_IDLE.getPhaseObject()/* , EEnderCalamityPhase.PHASE_LASERING.getPhaseObject() */ };
+		// return new IEnderCalamityPhase[] { EEnderCalamityPhase.PHASE_TELEPORT_LASER.getPhaseObject(), EEnderCalamityPhase.PHASE_IDLE.getPhaseObject()/* , EEnderCalamityPhase.PHASE_LASERING.getPhaseObject() */ };
 		return EEnderCalamityPhase.PHASE_IDLE.getPhaseObject().getPossibleSuccessors();
 	}
 
@@ -40,9 +40,9 @@ public class ECPhaseStunned implements IEnderCalamityPhase {
 	public boolean isPhaseTimed() {
 		return true;
 	}
-	
-	private static final int MIN_EXECUTION_TIME = 100; //5s
-	private static final int MAX_EXECUTION_TIME = 300; //15s
+
+	private static final int MIN_EXECUTION_TIME = 100; // 5s
+	private static final int MAX_EXECUTION_TIME = 300; // 15s
 
 	@Override
 	public Optional<Integer> getRandomExecutionTime() {

--- a/src/main/java/team/cqr/cqrepoured/entity/boss/exterminator/EntityCQRExterminator.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/boss/exterminator/EntityCQRExterminator.java
@@ -229,7 +229,7 @@ public class EntityCQRExterminator extends AbstractEntityCQRBoss implements IDon
 			public boolean shouldExecute() {
 				return super.shouldExecute() && !EntityCQRExterminator.this.isStunned();
 			}
-			
+
 			@Override
 			public boolean shouldContinueExecuting() {
 				return super.shouldContinueExecuting() && !EntityCQRExterminator.this.isStunned();
@@ -698,7 +698,7 @@ public class EntityCQRExterminator extends AbstractEntityCQRBoss implements IDon
 	// Kick handling
 	@Override
 	public boolean attackEntityAsMob(Entity entityIn) {
-		if(this.isStunned()) {
+		if (this.isStunned()) {
 			return false;
 		}
 		boolean result = super.attackEntityAsMob(entityIn);
@@ -1062,12 +1062,12 @@ public class EntityCQRExterminator extends AbstractEntityCQRBoss implements IDon
 
 	@Override
 	public void tick() {
-		
+
 	}
 
 	@Override
 	public int tickTimer() {
 		return this.ticksExisted;
 	}
-	
+
 }

--- a/src/main/java/team/cqr/cqrepoured/entity/boss/gianttortoise/EntityCQRGiantTortoise.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/boss/gianttortoise/EntityCQRGiantTortoise.java
@@ -742,7 +742,7 @@ public class EntityCQRGiantTortoise extends AbstractEntityCQRBoss implements IEn
 
 	@Override
 	public void tick() {
-		
+
 	}
 
 	@Override

--- a/src/main/java/team/cqr/cqrepoured/entity/mobs/EntityCQREnderman.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/mobs/EntityCQREnderman.java
@@ -23,7 +23,7 @@ import team.cqr.cqrepoured.init.CQRCreatureAttributes;
 import team.cqr.cqrepoured.init.CQRLoottables;
 
 public class EntityCQREnderman extends AbstractEntityCQR {
-	
+
 	protected boolean mayTeleport = true;
 
 	public EntityCQREnderman(World worldIn) {
@@ -39,11 +39,11 @@ public class EntityCQREnderman extends AbstractEntityCQR {
 		this.tasks.addTask(3, new EntityAITeleportToTargetWhenStuck<EntityCQREnderman>(this) {
 			@Override
 			public boolean shouldExecute() {
-				return EntityCQREnderman.this.mayTeleport && super.shouldExecute(); 
+				return EntityCQREnderman.this.mayTeleport && super.shouldExecute();
 			}
 		});
 	}
-	
+
 	public void setMayTeleport(boolean value) {
 		this.mayTeleport = value;
 	}
@@ -173,18 +173,18 @@ public class EntityCQREnderman extends AbstractEntityCQR {
 	public EnumCreatureAttribute getCreatureAttribute() {
 		return CQRCreatureAttributes.VOID;
 	}
-	
+
 	@Override
 	public void writeEntityToNBT(NBTTagCompound compound) {
 		super.writeEntityToNBT(compound);
 		compound.setBoolean("mayTeleport", mayTeleport);
 	}
-	
+
 	@Override
 	public void readEntityFromNBT(NBTTagCompound compound) {
 		super.readEntityFromNBT(compound);
 		this.mayTeleport = true;
-		if(compound.hasKey("mayTeleport")) {
+		if (compound.hasKey("mayTeleport")) {
 			this.mayTeleport = compound.getBoolean("mayTeleport");
 		}
 	}

--- a/src/main/java/team/cqr/cqrepoured/entity/projectiles/ProjectileBase.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/projectiles/ProjectileBase.java
@@ -29,8 +29,8 @@ public abstract class ProjectileBase extends EntityThrowable {
 	public boolean hasNoGravity() {
 		return true;
 	}
-	
-	//Dumb name, actually used to determine if a mob can travel through a portal or not
+
+	// Dumb name, actually used to determine if a mob can travel through a portal or not
 	@Override
 	public boolean isNonBoss() {
 		return false;
@@ -60,10 +60,10 @@ public abstract class ProjectileBase extends EntityThrowable {
 	protected void onUpdateInAir() {
 
 	}
-	
+
 	@Override
 	public void setPortal(BlockPos pos) {
-		//NOPE
+		// NOPE
 	}
 
 }

--- a/src/main/java/team/cqr/cqrepoured/entity/projectiles/ProjectileHookShotHook.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/projectiles/ProjectileHookShotHook.java
@@ -362,7 +362,7 @@ public class ProjectileHookShotHook extends ProjectileBase implements IEntityAdd
 		if (!this.world.isRemote) {
 			this.checkForEntityStuck(this.thrower);
 		} else {
-			if(this.thrower == null || !(this.thrower instanceof EntityPlayer && CQRMain.proxy.isPlayerCurrentClientPlayer((EntityPlayer) this.thrower))) {
+			if (this.thrower == null || !(this.thrower instanceof EntityPlayer && CQRMain.proxy.isPlayerCurrentClientPlayer((EntityPlayer) this.thrower))) {
 				return;
 			}
 		}
@@ -370,8 +370,8 @@ public class ProjectileHookShotHook extends ProjectileBase implements IEntityAdd
 		Vec3d v = this.getLatchedPos();
 		this.setPosition(v.x, v.y, v.z);
 
-		//TODO: Only run this code when on the server or the current client player is the thrower
-		
+		// TODO: Only run this code when on the server or the current client player is the thrower
+
 		Vec3d v1 = Vec3d.fromPitchYaw(0.0F, this.rotationYaw);
 		double x = this.posX - this.thrower.posX + v1.x * 0.1D;
 		double y = this.posY - this.thrower.posY + 1.0D;

--- a/src/main/java/team/cqr/cqrepoured/entity/trade/Trade.java
+++ b/src/main/java/team/cqr/cqrepoured/entity/trade/Trade.java
@@ -441,7 +441,7 @@ public class Trade {
 	public int getMaxStock() {
 		return this.maxStock;
 	}
-	
+
 	public boolean canRestock() {
 		return this.hasLimitedStock && this.restockRate > 0 && this.inStock < this.maxStock;
 	}

--- a/src/main/java/team/cqr/cqrepoured/event/world/structure/protection/ProtectedRegionEventHandler.java
+++ b/src/main/java/team/cqr/cqrepoured/event/world/structure/protection/ProtectedRegionEventHandler.java
@@ -106,12 +106,12 @@ public class ProtectedRegionEventHandler {
 		}
 		syncProtectedRegions(protectedRegionManager, (EntityPlayerMP) event.player);
 	}
-	
+
 	@SubscribeEvent
 	public static void onMobGriefing(EntityMobGriefingEvent event) {
 		Entity griefingFuck = event.getEntity();
-		//TODO: Move the instanceof check to a config based check (whitelist)
-		if(griefingFuck == null || griefingFuck instanceof AbstractEntityCQR) {
+		// TODO: Move the instanceof check to a config based check (whitelist)
+		if (griefingFuck == null || griefingFuck instanceof AbstractEntityCQR) {
 			return;
 		}
 		World world = griefingFuck.world;

--- a/src/main/java/team/cqr/cqrepoured/faction/FactionRegistry.java
+++ b/src/main/java/team/cqr/cqrepoured/faction/FactionRegistry.java
@@ -277,11 +277,11 @@ public class FactionRegistry {
 
 	@SuppressWarnings("unchecked")
 	private Faction getFactionOf(Class<? extends Entity> entityClass) {
-		if(entityClass == null) {
+		if (entityClass == null) {
 			CQRMain.logger.error("Class of entity is null! This should never happen!");
 			return null;
 		}
-		
+
 		Faction faction = this.entityFactionMap.get(entityClass);
 		if (faction == null && entityClass != Entity.class) {
 			faction = this.getFactionOf((Class<? extends Entity>) entityClass.getSuperclass());
@@ -416,11 +416,11 @@ public class FactionRegistry {
 		for (UUID playerID : this.playerFactionRepuMap.keySet()) {
 			this.savePlayerReputation(playerID);
 		}
-		if(removeMapsFromMemory) {
+		if (removeMapsFromMemory) {
 			this.playerFactionRepuMap.clear();
 		}
 	}
-	
+
 	public void savePlayerReputation(final UUID playerID) {
 		this.savePlayerReputation(playerID, false);
 	}

--- a/src/main/java/team/cqr/cqrepoured/item/ItemLore.java
+++ b/src/main/java/team/cqr/cqrepoured/item/ItemLore.java
@@ -20,7 +20,7 @@ public class ItemLore extends Item {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
-		if(this.hasLore(stack)) {
+		if (this.hasLore(stack)) {
 			if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
 				tooltip.add(TextFormatting.BLUE + I18n.format("description." + this.getRegistryName().getPath() + ".name", '\n', '\n', '\n', '\n', '\n', '\n', '\n', '\n', '\n', '\n'));
 			} else {
@@ -30,7 +30,7 @@ public class ItemLore extends Item {
 			super.addInformation(stack, worldIn, tooltip, flagIn);
 		}
 	}
-	
+
 	public boolean hasLore(ItemStack stack) {
 		return true;
 	}

--- a/src/main/java/team/cqr/cqrepoured/item/ItemSoulBottle.java
+++ b/src/main/java/team/cqr/cqrepoured/item/ItemSoulBottle.java
@@ -121,7 +121,7 @@ public class ItemSoulBottle extends Item {
 				}
 			}
 			Entity entity = EntityList.createEntityFromNBT(tag, worldIn);
-			if(entity == null) {
+			if (entity == null) {
 				return null;
 			}
 			entity.setPosition(x, y, z);

--- a/src/main/java/team/cqr/cqrepoured/item/ItemSpikedGlove.java
+++ b/src/main/java/team/cqr/cqrepoured/item/ItemSpikedGlove.java
@@ -68,7 +68,7 @@ public class ItemSpikedGlove extends Item {
 							}
 
 							entity.motionY = vY;
-							
+
 							this.createClimbingParticles(entity, worldIn);
 						} else if (entity.isSneaking()) {
 							entity.motionY = 0.0D;

--- a/src/main/java/team/cqr/cqrepoured/item/gun/ItemFlamethrower.java
+++ b/src/main/java/team/cqr/cqrepoured/item/gun/ItemFlamethrower.java
@@ -46,8 +46,8 @@ public class ItemFlamethrower extends ItemMagazineBased {
 		World world = entity.world;
 		float rotationYaw = MathHelper.wrapDegrees(entity.rotationYawHead);
 		double armDist = 1.0D;
-		if(entity instanceof ISizable) {
-			armDist *= ((ISizable)entity).getSizeVariation();
+		if (entity instanceof ISizable) {
+			armDist *= ((ISizable) entity).getSizeVariation();
 		}
 		double offY = entity.height * 0.75D;
 		double posX = entity.posX - Math.sin(Math.toRadians(rotationYaw)) * armDist;

--- a/src/main/java/team/cqr/cqrepoured/network/client/handler/CPacketHandlerSyncTrades.java
+++ b/src/main/java/team/cqr/cqrepoured/network/client/handler/CPacketHandlerSyncTrades.java
@@ -28,7 +28,8 @@ public class CPacketHandlerSyncTrades implements IMessageHandler<SPacketSyncTrad
 
 					trades.readFromNBT(message.getTrades());
 					if (player.openContainer instanceof ContainerMerchant) {
-						((ContainerMerchant) player.openContainer).onTradesUpdated();;
+						((ContainerMerchant) player.openContainer).onTradesUpdated();
+						;
 					}
 					CQRMain.proxy.updateGui();
 				}

--- a/src/main/java/team/cqr/cqrepoured/proxy/ClientProxy.java
+++ b/src/main/java/team/cqr/cqrepoured/proxy/ClientProxy.java
@@ -64,8 +64,7 @@ public class ClientProxy implements IProxy {
 		Minecraft.getMinecraft().getRenderManager().getSkinMap().values().forEach(t -> {
 			t.addLayer(new LayerElectrocute());
 			t.addLayer(new LayerCrownRenderer(t));
-			}
-		);
+		});
 	}
 
 	@Override
@@ -132,8 +131,8 @@ public class ClientProxy implements IProxy {
 
 	@Override
 	public boolean isPlayerCurrentClientPlayer(EntityPlayer player) {
-		if(player != null) {
-			return ((EntityPlayer)Minecraft.getMinecraft().player).equals(player);
+		if (player != null) {
+			return ((EntityPlayer) Minecraft.getMinecraft().player).equals(player);
 		}
 		return false;
 	}

--- a/src/main/java/team/cqr/cqrepoured/proxy/IProxy.java
+++ b/src/main/java/team/cqr/cqrepoured/proxy/IProxy.java
@@ -31,7 +31,7 @@ public interface IProxy {
 	void updateGui();
 
 	boolean isOwnerOfIntegratedServer(EntityPlayer player);
-	
+
 	boolean isPlayerCurrentClientPlayer(EntityPlayer player);
 
 	void openGui(int id, EntityPlayer player, World world, int... args);

--- a/src/main/java/team/cqr/cqrepoured/util/IntUtil.java
+++ b/src/main/java/team/cqr/cqrepoured/util/IntUtil.java
@@ -17,10 +17,10 @@ public class IntUtil {
 	}
 
 	/**
-	 * @param minX     inclusive
-	 * @param maxX     exclusive
-	 * @param minY     inclusive
-	 * @param maxY     exclusive
+	 * @param minX inclusive
+	 * @param maxX exclusive
+	 * @param minY inclusive
+	 * @param maxY exclusive
 	 * @param consumer
 	 */
 	public static void forEachXY(int minX, int maxX, int minY, int maxY, BiIntConsumer consumer) {
@@ -59,12 +59,12 @@ public class IntUtil {
 	}
 
 	/**
-	 * @param minX     inclusive
-	 * @param maxX     exclusive
-	 * @param minY     inclusive
-	 * @param maxY     exclusive
-	 * @param minZ     inclusive
-	 * @param maxZ     exclusive
+	 * @param minX inclusive
+	 * @param maxX exclusive
+	 * @param minY inclusive
+	 * @param maxY exclusive
+	 * @param minZ inclusive
+	 * @param maxZ exclusive
 	 * @param consumer
 	 */
 	public static void forEachXYZ(int minX, int maxX, int minY, int maxY, int minZ, int maxZ, TriIntConsumer consumer) {

--- a/src/main/java/team/cqr/cqrepoured/util/ItemUtil.java
+++ b/src/main/java/team/cqr/cqrepoured/util/ItemUtil.java
@@ -97,20 +97,20 @@ public class ItemUtil {
 	 * @param stack
 	 * @param player
 	 * @param targetEntity
-	 * @param fakeCrit                     If set to true and no real crit occurred it will spawn spell crit particles
-	 *                                     (vanilla: false)
-	 * @param damageBonus                  A flat damage bonus which affects the main attack and enchantments like sweeping
-	 *                                     edge (vanilla: 0.0F)
-	 * @param damageMultiplier             A damage multiplier which affects the main attack and enchantments like sweeping
-	 *                                     edge (vanilla: 1.0F)
-	 * @param sweepingEnabled              If set to false the player won't be able to make a sweeping attack with this item
-	 *                                     (vanilla: true)
-	 * @param sweepingDamage               The base amount of damage which the sweeping attack deals (vanilla: 1.0F)
+	 * @param fakeCrit If set to true and no real crit occurred it will spawn spell crit particles
+	 * (vanilla: false)
+	 * @param damageBonus A flat damage bonus which affects the main attack and enchantments like sweeping
+	 * edge (vanilla: 0.0F)
+	 * @param damageMultiplier A damage multiplier which affects the main attack and enchantments like sweeping
+	 * edge (vanilla: 1.0F)
+	 * @param sweepingEnabled If set to false the player won't be able to make a sweeping attack with this item
+	 * (vanilla: true)
+	 * @param sweepingDamage The base amount of damage which the sweeping attack deals (vanilla: 1.0F)
 	 * @param sweepingDamageMultiplicative A damage bonus for sweeping attacks based on the main attack damage (vanilla:
-	 *                                     0.0F)
-	 * @param sweepingRangeHorizontal      (vanilla: 1.0D)
-	 * @param sweepingRangeVertical        (vanilla: 0.25D)
-	 * @param sweepingKnockback            (vanilla: 0.4F)
+	 * 0.0F)
+	 * @param sweepingRangeHorizontal (vanilla: 1.0D)
+	 * @param sweepingRangeVertical (vanilla: 0.25D)
+	 * @param sweepingKnockback (vanilla: 0.4F)
 	 */
 	public static void attackTarget(ItemStack stack, EntityPlayer player, Entity targetEntity, boolean fakeCrit, float damageBonus, float damageMultiplier, boolean sweepingEnabled, float sweepingDamage, float sweepingDamageMultiplicative, double sweepingRangeHorizontal, double sweepingRangeVertical,
 			float sweepingKnockback) {

--- a/src/main/java/team/cqr/cqrepoured/util/SpawnerFactory.java
+++ b/src/main/java/team/cqr/cqrepoured/util/SpawnerFactory.java
@@ -40,11 +40,11 @@ public final class SpawnerFactory {
 	 * Places a spawner in the provided world at the provided position. Spawner type (CQR/vanilla) is determined dynamically
 	 * based upon the requested capabilities.
 	 * 
-	 * @param entities                 Entities for spawner to spawn
-	 * @param multiUseSpawner          Determines spawner type. Vanilla = true; CQR = false.
+	 * @param entities Entities for spawner to spawn
+	 * @param multiUseSpawner Determines spawner type. Vanilla = true; CQR = false.
 	 * @param spawnerSettingsOverrides Settings to be applied if generating vanilla spawner (can be null if CQR spawner)
-	 * @param world                    World in which to place spawner
-	 * @param pos                      Position at which to place spawner
+	 * @param world World in which to place spawner
+	 * @param pos Position at which to place spawner
 	 */
 	public static void placeSpawner(Entity[] entities, boolean multiUseSpawner, @Nullable NBTTagCompound spawnerSettingsOverrides, World world, BlockPos pos) {
 		NBTTagCompound[] entCompounds = new NBTTagCompound[entities.length];
@@ -62,11 +62,11 @@ public final class SpawnerFactory {
 	 * Places a spawner in the provided world at the provided position. Spawner type (CQR/vanilla) is determined dynamically
 	 * based upon the requested capabilities.
 	 * 
-	 * @param entities                 Entities as NBT Tag (From Entity.writeToNBTOptional(COMPOUND) for spawner to spawn
-	 * @param multiUseSpawner          Determines spawner type. Vanilla = true; CQR = false.
+	 * @param entities Entities as NBT Tag (From Entity.writeToNBTOptional(COMPOUND) for spawner to spawn
+	 * @param multiUseSpawner Determines spawner type. Vanilla = true; CQR = false.
 	 * @param spawnerSettingsOverrides Settings to be applied if generating vanilla spawner (can be null if CQR spawner)
-	 * @param world                    World in which to place spawner
-	 * @param pos                      Position at which to place spawner
+	 * @param world World in which to place spawner
+	 * @param pos Position at which to place spawner
 	 */
 	public static void placeSpawner(NBTTagCompound[] entities, boolean multiUseSpawner, @Nullable NBTTagCompound spawnerSettingsOverrides, World world, BlockPos pos) {
 		world.setBlockState(pos, multiUseSpawner ? Blocks.MOB_SPAWNER.getDefaultState() : CQRBlocks.SPAWNER.getDefaultState());

--- a/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
+++ b/src/main/java/team/cqr/cqrepoured/util/datafixer/StructureUpper.java
@@ -50,6 +50,7 @@ public class StructureUpper {
 			protected boolean isChunkLoaded(int x, int z, boolean allowEmpty) {
 				return false;
 			}
+
 			@Override
 			protected IChunkProvider createChunkProvider() {
 				return null;
@@ -145,7 +146,7 @@ public class StructureUpper {
 
 	private static void setBlock(World world, Map<ChunkPos, ChunkTileEntityContainer> chunks, BlockPos pos, IBlockState state, @Nullable NBTTagCompound tileEntity) {
 		ChunkTileEntityContainer chunk = getChunk(world, chunks, pos);
-		
+
 		ExtendedBlockStorage[] sections = chunk.chunk.getBlockStorageArray();
 		ExtendedBlockStorage section = sections[pos.getY() >> 4];
 		if (section == null) {
@@ -176,7 +177,7 @@ public class StructureUpper {
 	}
 
 	private static class ChunkTileEntityContainer {
-		
+
 		private static final AnvilChunkLoader CHUNK_SERIALIZER = new AnvilChunkLoader(null, null);
 		private static final ReflectionMethod<Void> M_WRITE_CHUNK_TO_NBT = new ReflectionMethod<>(AnvilChunkLoader.class, "writeChunkToNBT", "TODO", Chunk.class, World.class, NBTTagCompound.class);
 		private final Chunk chunk;
@@ -188,7 +189,7 @@ public class StructureUpper {
 		}
 
 		public NBTTagCompound save(NBTTagCompound nbt) {
-            NBTTagCompound nbt1 = new NBTTagCompound();
+			NBTTagCompound nbt1 = new NBTTagCompound();
 			M_WRITE_CHUNK_TO_NBT.invoke(CHUNK_SERIALIZER, chunk, chunk.getWorld(), nbt1);
 			nbt1.setTag("TileEntities", tileEntities);
 			nbt1.setTag("Entities", entities);
@@ -198,5 +199,5 @@ public class StructureUpper {
 		}
 
 	}
-	
+
 }

--- a/src/main/java/team/cqr/cqrepoured/world/ChunkCacheCQR.java
+++ b/src/main/java/team/cqr/cqrepoured/world/ChunkCacheCQR.java
@@ -8,11 +8,11 @@ import net.minecraft.world.chunk.Chunk;
 public class ChunkCacheCQR extends ChunkCache {
 
 	/**
-	 * @param worldIn    The world from which the chunks will get taken.
-	 * @param pos1       The start position from which to cache chunks.
-	 * @param pos2       The end position to which to cache chunks.
-	 * @param pos3       The chunk that gets loaded despite having loadChunks=false. pos1 is clamped to be at most pos3.
-	 *                   pos2 is clamped to be at least pos3.
+	 * @param worldIn The world from which the chunks will get taken.
+	 * @param pos1 The start position from which to cache chunks.
+	 * @param pos2 The end position to which to cache chunks.
+	 * @param pos3 The chunk that gets loaded despite having loadChunks=false. pos1 is clamped to be at most pos3.
+	 * pos2 is clamped to be at least pos3.
 	 * @param loadChunks Whether chunks should be loaded or not.
 	 */
 	public ChunkCacheCQR(World worldIn, BlockPos pos1, BlockPos pos2, BlockPos pos3, boolean loadChunks) {
@@ -39,12 +39,12 @@ public class ChunkCacheCQR extends ChunkCache {
 	}
 
 	/**
-	 * @param worldIn    The world from which the chunks will get taken.
-	 * @param pos1       The start position from which to cache chunks.
-	 * @param pos2       The end position to which to cache chunks.
-	 * @param pos3       The chunk that gets loaded despite having loadChunks=false.
+	 * @param worldIn The world from which the chunks will get taken.
+	 * @param pos1 The start position from which to cache chunks.
+	 * @param pos2 The end position to which to cache chunks.
+	 * @param pos3 The chunk that gets loaded despite having loadChunks=false.
 	 * @param blockRange If a chunk corner is less than this value away from the line between pos1 and pos2 this chunk will
-	 *                   get cached.
+	 * get cached.
 	 * @param loadChunks Whether chunks should be loaded or not.
 	 */
 	public ChunkCacheCQR(World worldIn, BlockPos pos1, BlockPos pos2, BlockPos pos3, int blockRange, boolean loadChunks) {

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/WorldDungeonGenerator.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/WorldDungeonGenerator.java
@@ -71,7 +71,7 @@ public class WorldDungeonGenerator implements IWorldGenerator {
 
 	/**
 	 * @return true when structure genration is enabled for this world and either the world is no flat world or dungeons can
-	 *         generate in flat worlds
+	 * generate in flat worlds
 	 */
 	public static boolean canSpawnDungeonsInWorld(World world) {
 		// Check if structures are enabled for this world

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/dungeons/DungeonVolcano.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/dungeons/DungeonVolcano.java
@@ -133,7 +133,7 @@ public class DungeonVolcano extends DungeonBase {
 	public GeneratorVolcano createDungeonGenerator(World world, int x, int y, int z, Random rand, DungeonDataManager.DungeonSpawnType spawnType) {
 		return new GeneratorVolcano(world, new BlockPos(x, y, z), this, rand);
 	}
-	
+
 	private File getDirForRoomType(EStrongholdRoomType type) {
 		File dir = null;
 		switch (type) {
@@ -201,11 +201,11 @@ public class DungeonVolcano extends DungeonBase {
 		}
 		return null;
 	}
-	
+
 	public int getRoomNBTCountForType(EStrongholdRoomType type) {
 		File dir = this.getDirForRoomType(type);
 		if (dir != null) {
-			return FileUtils.listFiles(dir, new String[] { "nbt"}, true).size();
+			return FileUtils.listFiles(dir, new String[] { "nbt" }, true).size();
 		} else {
 			return 0;
 		}

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generation/part/PlateauDungeonPart.java
@@ -114,9 +114,9 @@ public class PlateauDungeonPart implements IDungeonPart {
 		return material.blocksMovement() && material != Material.WOOD && material != Material.LEAVES && material != Material.PLANTS;
 	}
 
-	//TODO: Adjust in 1.17+ to automatically adapt to the world!
+	// TODO: Adjust in 1.17+ to automatically adapt to the world!
 	public static final int LOWEST_WORLD_Y = 0;
-	
+
 	private static int getHeight(World world, int x, int y, int z) {
 		Chunk chunk = world.getChunk(x >> 4, z >> 4);
 		MUTABLE.setPos(x, y, z);

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/GeneratorStrongholdOpen.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/GeneratorStrongholdOpen.java
@@ -154,10 +154,10 @@ public class GeneratorStrongholdOpen extends AbstractDungeonGenerator<DungeonStr
 		CQStructure structure = this.loadStructureFromFile(building);
 		if (this.dungeon.doBuildSupportPlatform()) {
 			PlateauDungeonPart.Builder partBuilder = new PlateauDungeonPart.Builder(
-					this.pos.getX() + 4 + structure.getSize().getX() / 2, 
-					this.pos.getZ() + 4 + structure.getSize().getZ() / 2, 
-					this.pos.getX() - 4 - structure.getSize().getX() / 2, 
-					this.pos.getY(), 
+					this.pos.getX() + 4 + structure.getSize().getX() / 2,
+					this.pos.getZ() + 4 + structure.getSize().getZ() / 2,
+					this.pos.getX() - 4 - structure.getSize().getX() / 2,
+					this.pos.getY(),
 					this.pos.getZ() - 4 - structure.getSize().getZ() / 2,
 					CQRConfig.general.supportHillWallSize);
 			partBuilder.setSupportHillBlock(this.dungeon.getSupportBlock());

--- a/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/spiral/SpiralStrongholdFloor.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/generation/generators/stronghold/spiral/SpiralStrongholdFloor.java
@@ -255,7 +255,7 @@ public class SpiralStrongholdFloor {
 							}
 							File file = dungeon.getRoomNBTFileForType(type, this.random);
 							if (file.equals(previous) && dungeon.getRoomNBTCountForType(prevType) > 1) {
-								int counter = 0; 
+								int counter = 0;
 								while (file.equals(previous) && counter < 8) {
 									counter++;
 									file = dungeon.getRoomNBTFileForType(type, this.random);

--- a/src/main/java/team/cqr/cqrepoured/world/structure/protection/ServerProtectedRegionManager.java
+++ b/src/main/java/team/cqr/cqrepoured/world/structure/protection/ServerProtectedRegionManager.java
@@ -178,12 +178,12 @@ public class ServerProtectedRegionManager implements IProtectedRegionManager {
 		return regionsTmp;
 		/*return () -> new Iterator<ProtectedRegion>() {
 			private final Iterator<ProtectedRegionContainer> iterator = Collections.unmodifiableCollection(ServerProtectedRegionManager.this.protectedRegions.values()).iterator();
-
+		
 			@Override
 			public boolean hasNext() {
 				return this.iterator.hasNext();
 			}
-
+		
 			@Override
 			public ProtectedRegion next() {
 				return this.iterator.next().protectedRegion;


### PR DESCRIPTION
Checking format and review manually is really time-consuming ( #425 ), so this PR added Spotless, allowing me to run formatter via gradle command, to at least mitigate this problem.

- `./gradlew spotlessCheck` to check code format
- `./gradlew spotlessApply` to run formatter (preconfigured to use Eclipse formatter and `./eclipse code style/CQR_formatter.xml` config)
- There'a also an additional step in workflow to check code format automatically

Note that imports are not reordered using this setup, code cleanness (e.g. usage of `var`) is also not checked.